### PR TITLE
Auto select readable

### DIFF
--- a/data/extractor-worker.js
+++ b/data/extractor-worker.js
@@ -81,14 +81,4 @@ function findImages(elements) {
   return images;
 }
 
-try {
-  self.port.emit("data", watchFunction(extractData)());
-} catch (e) {
-  console.error("Error in extractor-worker.js:", e+"");
-  console.trace();
-  self.port.emit("alertError", {
-    name: e.name || "ERROR",
-    message: "Error in extractor-worker.js: " + e,
-    help: "There was an error getting data from the page."
-  });
-}
+self.port.emit("data", watchFunction(extractData)());

--- a/data/extractor-worker.js
+++ b/data/extractor-worker.js
@@ -9,6 +9,35 @@
 // Set for use in error messages:
 var FILENAME = "extractor-worker.js";
 
+function getDocument() {
+  return document;
+}
+
+// FIXME: this is an exact copy of the same code in make-static-html
+// But we are running it in both places, CONCURRENTLY, to try to make sure the
+// ids are set in both places consistently.  Crazy, I know.
+var idCount = 0;
+/** makeId() creates new ids that we give to elements that don't already have an id */
+function makeId() {
+  idCount++;
+  return 'psid-' + idCount;
+}
+
+function setIds() {
+  var els = getDocument().getElementsByTagName("*");
+  var len = els.length;
+  for (var i=0; i<len; i++) {
+    var el = els[i];
+    var curId = el.id;
+    if (curId && curId.indexOf("psid-") === 0) {
+      idCount = parseInt(curId.substr(5), 10);
+    } else if (! curId) {
+      el.id = makeId();
+    }
+  }
+}
+
+
 /** Extracts data:
     - Gets the Readability version of the page (`.readable`)
     - Parses out microformats (`.microdata`)
@@ -16,6 +45,7 @@ var FILENAME = "extractor-worker.js";
     */
 function extractData() {
   // Readability is destructive, so we have to run it on a copy
+  setIds();
   var readableDiv = document.createElement("div");
   readableDiv.innerHTML = document.body.innerHTML;
   // FIXME: location.href isn't what Readability expects (but I am

--- a/data/framescripts/make-static-html.js
+++ b/data/framescripts/make-static-html.js
@@ -111,13 +111,6 @@ function skipElement(el) {
 const TEXT_NODE = getDocument().TEXT_NODE;
 const ELEMENT_NODE = getDocument().ELEMENT_NODE;
 
-var idCount = 0;
-/** makeId() creates new ids that we give to elements that don't already have an id */
-function makeId() {
-  idCount++;
-  return 'psid-' + idCount;
-}
-
 // Used when an iframe fails to serialize:
 var NULL_IFRAME = '<html></html>';
 
@@ -265,9 +258,31 @@ function documentStaticData() {
   };
 }
 
+var idCount = 0;
+/** makeId() creates new ids that we give to elements that don't already have an id */
+function makeId() {
+  idCount++;
+  return 'psid-' + idCount;
+}
+
+function setIds() {
+  var els = getDocument().getElementsByTagName("*");
+  var len = els.length;
+  for (var i=0; i<len; i++) {
+    var el = els[i];
+    var curId = el.id;
+    if (curId && curId.indexOf("psid-") === 0) {
+      idCount = parseInt(curId.substr(5), 10);
+    } else if (! curId) {
+      el.id = makeId();
+    }
+  }
+}
+
 addMessageListener("pageshot@documentStaticData:call", function (event) {
   var result;
   try {
+    setIds();
     result = documentStaticData();
   } catch (e) {
     console.log("Error getting static HTML:", e);

--- a/data/vendor/Readability.js
+++ b/data/vendor/Readability.js
@@ -183,6 +183,11 @@ Readability.prototype = {
         curTitle = origTitle = this._getInnerText(doc.getElementsByTagName('title')[0]);
     } catch(e) {}
 
+    var ogTitle = doc.ownerDocument.querySelector("meta[content='og:title']");
+    if (ogTitle && ogTitle.getAttribute("content")) {
+      curTitle = ogTitle.getAttribute("content");
+    }
+
     if (curTitle.match(/ [\|\-] /)) {
       curTitle = origTitle.replace(/(.*)[\|\-] .*/gi,'$1');
 
@@ -1536,12 +1541,27 @@ Readability.prototype = {
     // }
 
     let excerpt = this._getExcerpt(articleContent);
+    var readableIds = [];
+    function traverse(parent) {
+      for (var i=0; i<parent.childNodes.length; i++) {
+        var el = parent.childNodes[i];
+        if (el.id && el.id.indexOf("readability-") === 0) {
+          traverse(el);
+          continue;
+        }
+        if (el.id) {
+          readableIds.push(el.id);
+        }
+      }
+    }
+    traverse(articleContent);
 
     return { title: articleTitle,
              byline: this._articleByline,
              dir: this._articleDir,
              content: articleContent.innerHTML,
              length: articleContent.textContent.length,
-             excerpt: excerpt };
+             excerpt: excerpt,
+             readableIds: readableIds };
   }
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -103,7 +103,9 @@ const PanelContext = {
       this.addContext(shotContext);
       this.show(shotContext);
     } else {
-      shootPanel.show(this._activeContext);
+      if (this._activeContext.couldBeActive()) {
+        shootPanel.show(this._activeContext);
+      }
     }
   },
 

--- a/lib/shooter.js
+++ b/lib/shooter.js
@@ -189,26 +189,33 @@ const ShotContext = Class({
       microformat stuff, the HTML, and other misc stuff.  Immediately updates the
       shot as that information comes in */
   collectInformation: function () {
+    var promises = [];
     this.shot.history = processHistory(this.tab);
-    watchPromise(captureTab(this.tab, null, {h: 200, w: 350}).then((function (url) {
-      this.updateShot({screenshot: url});
-    }.bind(this))));
-    watchPromise(extractWorker(this.tab)).then(watchFunction(function (attrs) {
-      this.updateShot(attrs);
-    }, this));
-    watchPromise(callScript(
+    promises.push(watchPromise(captureTab(this.tab, null, {h: 200, w: 350}).then((function (url) {
+      this.updateShot({screenshot: url}, true);
+    }.bind(this)))));
+    promises.push(watchPromise(extractWorker(this.tab)).then(watchFunction(function (attrs) {
+      this.interactiveWorker.port.emit("extractedData", attrs);
+      this.updateShot(attrs, true);
+    }, this)));
+    promises.push(watchPromise(callScript(
       this.tab,
       self.data.url("framescripts/make-static-html.js"),
       "pageshot@documentStaticData",
       {})).then(watchFunction(function (attrs) {
-        this.updateShot(attrs);
-      }, this));
+        this.updateShot(attrs, true);
+      }, this)));
+    watchPromise(allPromisesComplete(promises).then((function () {
+      this.shot.save();
+    }).bind(this)));
   },
 
   /** Sets attributes on the shot, saves it, and updates the panel */
-  updateShot: function (attrs) {
+  updateShot: function (attrs, dontSave) {
     this.shot.set(attrs);
-    this.shot.save();
+    if (! dontSave) {
+      this.shot.save();
+    }
     this.panelContext.updateShot(this);
   },
 
@@ -296,6 +303,13 @@ const Shot = Class({
       `/meta/{id}` - returns a promise that resolves when save is complete */
   save: function () {
     let deferred = defer();
+    // We keep copies of these lists so we don't get confused if more items are
+    // added to these lists while we are being called:
+    // FIXME: maybe we should actually clear these lists right away, and unclear
+    // them if the update fails?  Then we would catch two overlapping updates
+    // of the same attribute
+    let dirtyMeta = this.dirtyMeta.slice();
+    let dirtyData = this.dirtyData.slice();
     for (let i=0; i<this.SERVER_REQUIRED_ATTRS.length; i++) {
       let attr = this.SERVER_REQUIRED_ATTRS[i];
       if (! this[attr]) {
@@ -305,15 +319,15 @@ const Shot = Class({
         return deferred.promise;
       }
     }
-    let metaDone = ! this.dirtyMeta.length;
-    let dataDone = ! (this.dirtyData.length || ! this.created);
+    let metaDone = ! dirtyMeta.length;
+    let dataDone = ! (dirtyData.length || ! this.created);
     if (! dataDone) {
       // FIXME: we should also refresh any data when we have the opporunity here:
-      let dirtyData = this._collectAttrs(this.dirtyData);
-      this._updateInPlace(this.dataUrl, dirtyData)
+      let dirtyDataAttrs = this._collectAttrs(dirtyData);
+      this._updateInPlace(this.dataUrl, dirtyDataAttrs)
           .then((function () {
             dataDone = true;
-            this.dirtyData = [];
+            removeListItems(this.dirtyData, dirtyData);
             if (metaDone) {
               deferred.resolve();
             }
@@ -322,11 +336,11 @@ const Shot = Class({
           });
     }
     if (! metaDone) {
-      let dirtyMeta = this._collectAttrs(this.dirtyMeta);
-      this._updateInPlace(this.metaUrl, dirtyMeta)
+      let dirtyMetaAttrs = this._collectAttrs(dirtyMeta);
+      this._updateInPlace(this.metaUrl, dirtyMetaAttrs)
         .then((function () {
           metaDone = true;
-          this.dirtyMeta = [];
+          removeListItems(this.dirtyMeta, dirtyMeta);
           if (dataDone) {
             deferred.resolve();
           }
@@ -372,8 +386,10 @@ const Shot = Class({
       // An update is already happening
       console.log("Deferring save to", url, "due to lock");
       return watchPromise(this.resourceLocks[url].then((function () {
+        console.log("Retrying save of", Object.keys(attrs).join(", "));
         this._updateInPlace(url, attrs);
       }).bind(this), (function () {
+        console.log("Retrying save of", Object.keys(attrs).join(", "), "after failure");
         this._updateInPlace(url, attrs);
       }).bind(this)));
     }
@@ -408,7 +424,7 @@ const Shot = Class({
         for (let attr in attrs) {
           body[attr] = attrs[attr];
         }
-        console.log("PUT", url);
+        console.log("PUT", url, "with updates", Object.keys(attrs).join(", "));
         Request({
           url: url,
           content: JSON.stringify(body),
@@ -431,3 +447,30 @@ const Shot = Class({
   }
 
 });
+
+function removeListItems(list, toRemove) {
+  for (var i=0; i<toRemove.length; i++) {
+    var index = list.indexOf(toRemove[i]);
+    if (index == -1) {
+      throw new Error("Item " + JSON.stringify(toRemove[i]) + " not found in list " + JSON.stringify(list));
+    }
+    list.splice(index, 1);
+  }
+}
+
+/** Returns a promise that resolves when all the promises in the array are complete
+    (regardless of success or failure of each promise!) */
+function allPromisesComplete(promises) {
+  var deferred = defer();
+  var count = promises.length;
+  function done() {
+    count--;
+    if (! count) {
+      deferred.resolve();
+    }
+  }
+  for (var i=0; i<promises.length; i++) {
+    promises[i].then(done, done);
+  }
+  return deferred.promise;
+}

--- a/lib/shooter.js
+++ b/lib/shooter.js
@@ -77,7 +77,7 @@ function extractWorker(tab) {
                         self.data.url("extractor-worker.js")]
   });
   watchWorker(worker);
-  worker.port.on("extractedData", function (data) {
+  worker.port.on("data", function (data) {
     worker.destroy();
     deferred.resolve(data);
   });
@@ -194,7 +194,6 @@ const ShotContext = Class({
       this.updateShot({screenshot: url});
     }.bind(this))));
     watchPromise(extractWorker(this.tab)).then(watchFunction(function (attrs) {
-      console.log("got extraction", this.id, Object.keys(attrs));
       this.updateShot(attrs);
     }, this));
     watchPromise(callScript(
@@ -372,12 +371,11 @@ const Shot = Class({
     if (this.resourceLocks[url]) {
       // An update is already happening
       console.log("Deferring save to", url, "due to lock");
-      watchPromise(this.resourceLocks[url].then((function () {
+      return watchPromise(this.resourceLocks[url].then((function () {
         this._updateInPlace(url, attrs);
       }).bind(this), (function () {
         this._updateInPlace(url, attrs);
       }).bind(this)));
-      return;
     }
     let promise = this._doUpdateInPlace(url, attrs);
     this.resourceLocks[url] = promise;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Take and share shots of the sites you are on",
   "author": "Ian Bicking",
   "license": "MPL 2.0",
-  "version": "0.1",
+  "version": "0.1.201503122124",
   "preferences": [
     {
       "name": "backend",

--- a/run
+++ b/run
@@ -129,6 +129,15 @@ if [[ -n "$publish" ]] ; then
     if [ -e ~/appengine-password.txt ] ; then
         echo "Appengine password: $(cat ~/appengine-password.txt)"
     fi
+    python -c 'import sys, re, time
+today = time.strftime("%Y%m%d%H%M")
+content = sys.stdin.read().strip()
+def repl(match):
+    return match.group(1) + today
+content = re.sub(r"(\"version\": \"\d+\.\d+\.)(\d+)", repl, content)
+print content
+' < package.json > package.json.tmp
+    mv package.json.tmp package.json
     cfx xpi \
         --update-link https://pageshotpages.appspot.com/pageshot.xpi \
         --update-url https://pageshotpages.appspot.com/pageshot.update.rdf


### PR DESCRIPTION
@fzzzy – This contains a bunch of updates.

The primary feature is that it autoselects content when you make a shot.  It uses the Readability library to hint at what is most interesting.  It then finds block elements that are contained fully within the viewable screen, and uses them as the boundary.  There's a noticeable performance hit, but I'm not sure exactly why.  The function that should be doing the work (`autoSelect()`) doesn't seem to take much time on the wall clock.

It should improve snapping some, I wasn't calculating positions correctly (getBoundingClientRect returns viewport-relative numbers), but it still doesn't feel awesome.  Not sure if there's too many snap lines or something else.

We'll have to open a bug about the Readability.js changes, to get them upstream.  We should probably fork that library too so we don't have to rely on upstream.

I made a guess that updating doesn't work if you don't bump version in `package.json`, so this attempts to do this on every publish.  But I can't get it to actually work in practice.  Not sure how to debug.

Also fixes making a bunch of PUT requests when making a shot, to instead make on PUT request.  Works around Appengine being annoying about commits, but also sensible.