### PR TITLE
Fix #181, track in-place updates of location.

### DIFF
--- a/data/shooter-interactive-worker.js
+++ b/data/shooter-interactive-worker.js
@@ -72,6 +72,11 @@ function reportSelection() {
     // Apparently no selection
     throw new Error("reportSelection() without any selection");
   }
+  var pos = getPos();
+  if (pos.top == pos.bottom || pos.right == pos.left) {
+    console.log("Suppressing null selection");
+    return;
+  }
   self.port.emit("select", getPos());
 }
 
@@ -433,6 +438,20 @@ function autoSelect(ids) {
   reportSelection();
 }
 
+var origUrl = location.href;
+function checkUrl() {
+  var curUrl = location.href;
+  console.log("got url change", origUrl, curUrl);
+  if (origUrl != curUrl) {
+    self.port.emit("popstate", curUrl);
+    setState("cancel");
+  }
+}
+
+window.addEventListener("popstate", checkUrl, false);
+
+self.port.on("isShowing", checkUrl);
+
 self.port.on("extractedData", watchFunction(function (data) {
   var ids = null;
   if (data.readable) {
@@ -443,7 +462,7 @@ self.port.on("extractedData", watchFunction(function (data) {
   }
   var now = Date.now();
   autoSelect(ids);
-  console.log("autoSelect took:", Date.now() - now, "milliseconds")
+  console.log("autoSelect took:", Date.now() - now, "milliseconds");
 }));
 
 self.port.emit("ready");

--- a/lib/main.js
+++ b/lib/main.js
@@ -90,12 +90,25 @@ const PanelContext = {
   /** Fired whenever the toolbar button is clicked, this activates
       a ShotContext, or creates a new one, or hides the panel */
   onShootButtonClicked: function () {
+    /* FIXME: remove, once I'm sure the panel really works right...
+    console.log(
+      "onShootButtonClicked.  activeContext:",
+      this._activeContext ? this._activeContext.tabUrl : "none",
+      this._activeContext ? this._activeContext.couldBeActive() : "",
+      "any good contexts?",
+      Object.keys(this._contexts).map((function (id) {
+        return this._contexts[id];
+      }).bind(this)).filter(function (context) {
+        return context.couldBeActive();
+      }).map(function (context) {
+        return context.tabUrl;
+      })
+    ); */
     if (! this._activeContext) {
       for (let id in this._contexts) {
         let shotContext = this._contexts[id];
         if (shotContext.couldBeActive()) {
           this.show(shotContext);
-          console.log("found", shotContext.id);
           return;
         }
       }
@@ -122,6 +135,8 @@ const PanelContext = {
       registration with this PanelContext */
   removeContext: function (shotContext) {
     if (! this._contexts[shotContext.id]) {
+      // FIXME: this sometimes throws on browser shutdown,
+      // not sure why.  Something must be double-destroying.
       throw new Error("No such context: " + shotContext.id);
     }
     if (this._activeContext == shotContext) {
@@ -159,7 +174,7 @@ exports.getBackend = function () {
 
 exports.main = function (options) {
   if (options.staticArgs.backend) {
-    console.log("Using backend", options.staticArgs.backend, "instead of", prefs.backend);
+    console.info("Using backend", options.staticArgs.backend, "instead of", prefs.backend);
     backendOverride = options.staticArgs.backend;
   }
 

--- a/lib/shooter.js
+++ b/lib/shooter.js
@@ -150,6 +150,9 @@ const ShotContext = Class({
         this.panelContext.show(this);
       }).bind(this)));
     }, this));
+    this.interactiveWorker.port.on("popstate", watchFunction(function (newUrl) {
+      this.destroy();
+    }, this));
     this._workerActive = true;
   },
 
@@ -158,6 +161,7 @@ const ShotContext = Class({
     if (! this._workerActive) {
       this._activateWorker();
     }
+    this.interactiveWorker.port.emit("isShowing");
   },
 
   /** True if it would be reasonable to open this context's panel */
@@ -236,6 +240,7 @@ const ShotContext = Class({
     this._deregisters = null;
     this.panelContext.removeContext(this);
     this.panelContext = null;
+    this.interactiveWorker.port.emit("setState", "cancel");
     this.interactiveWorker.destroy();
     this.interactiveWorker = null;
   }


### PR DESCRIPTION
@fzzzy Fix #181, track in-place updates of location.
Avoid sending null selections (a partial fix - we shouldn't let people update the selection with a click and no drag)