### PR TITLE
Move the delete button so it doesn't scroll with the clip. Fixes #338

### DIFF
--- a/addon/data/panel.css
+++ b/addon/data/panel.css
@@ -233,6 +233,6 @@ img.snippet-image {
   z-index: 10;
   cursor: pointer;
   position: absolute;
-  right: 0px;
-  top: 0px;
+  left: 0.5em;
+  top: 4.5em;
 }

--- a/addon/data/shoot-panel.js
+++ b/addon/data/shoot-panel.js
@@ -176,9 +176,9 @@ let ShootPanel = React.createClass({
           Visible
         </span>
       </div>
+      {deleter}
       <div className="snippet-container">
         {clipComponent}
-        {deleter}
       </div>
       <div className="snippets-row">
         {selectors}


### PR DESCRIPTION
It looked strange on the right side because it overlaps with the scroll bar, so I moved it to the left side, but it still looks a little strange there, too.