### PR TITLE
httpServerPort type is integer, not string

### DIFF
--- a/addon/package.json
+++ b/addon/package.json
@@ -29,8 +29,8 @@
       "name": "httpServerPort",
       "title": "HTTP server: port to listen on",
       "description": "port for the HTTP server to listen on",
-      "type": "string",
-      "value": "10082"
+      "type": "integer",
+      "value": 10082
     },
     {
       "name": "httpServerIp",


### PR DESCRIPTION
I for some reason left the port type as "string" when it should have been int. This resolves it.