### PR TITLE
Readable headless

### DIFF
--- a/addon/lib/headless.js
+++ b/addon/lib/headless.js
@@ -130,7 +130,7 @@ function handleReadableRequest(request, response) {
       tab.on("close", function () {     // When the tab is closed we know autoshot is done, so return the URL
         console.log('completed processing BACK'.replace('BACK', backendUrl));
         response.setStatusLine("1.1", 200, "OK");
-        response.write(backendUrl + '\n');
+        response.write("localhost:10081/content/" + backendUrl + '\n');
         response.finish();
       });
     }

--- a/addon/lib/headless.js
+++ b/addon/lib/headless.js
@@ -52,6 +52,7 @@ exports.init = function init(prefs) {
   var server = new nsHttpServer();
   server.start(port);
   server.registerPathHandler('/', handleRequest);
+  server.registerPathHandler('/readable/', handleReadableRequest);
 };
 
 function handleRequest(request, response) {
@@ -70,6 +71,58 @@ function handleRequest(request, response) {
     "onLoad": function (tab) {
       autoShot(tab, backend, backendUrl);
       tab.on("close", function (a) {
+        console.log('completed processing BACK'.replace('BACK', backendUrl));
+        response.setStatusLine("1.1", 200, "OK");
+        response.write(contentServerString + backendUrl + '\n');
+        response.finish();
+      });
+    }
+  });
+}
+
+function sleep(milliseconds) {
+  var start = new Date().getTime();
+  for (var i = 0; i < 1e7; i++) {
+    if ((new Date().getTime() - start) > milliseconds){
+      break;
+    }
+  }
+}
+
+function handleReadableRequest(request, response) {
+  var fired = false;        // Assign local variable fired, because onload gets tricky
+  response.processAsync();  // Tell response handler this is going to take a while
+  var url = request._queryString; // Grab the passed URL 
+  var backendUrl = randomString(RANDOM_STRING_LENGTH) + "/" + urlDomainForId(url); // Create backend url, usually happens in shooter.js
+  console.log('recieved request: URL -> BACK'   // Log both URLs
+                .replace('URL', url).replace('BACK', backendUrl));
+
+  tabs.open({                   // Open a tab
+    "url": url,
+    "onOpen": function (tab) {  // When the tab opens, run this on it
+      tab.on("load", function (tab) { 
+        if (!fired) {           // If it hasn't fired, click on readable button
+          fired = true;
+          var wm = Cc["@mozilla.org/appshell/window-mediator;1"]
+                             .getService(Ci.nsIWindowMediator);
+          var browserWindow = wm.getMostRecentWindow("navigator:browser");
+          browserWindow.document.getElementById("reader-mode-button").click();
+        } else {                // If it has fired, remove the toolbar
+          var worker = tab.attach({
+            contentScript:
+              'var toolbar = document.getElementById("reader-toolbar");\n' +
+              'toolbar.parentElement.removeChild(toolbar);\n' +
+              'self.port.emit("done");'
+          });
+          worker.port.on("done", function () { // When the worker emits done, wait a bit then fire autoshot
+            console.log('readability should be finished');
+            sleep(500000);
+            autoShot(tab, backend, backendUrl);
+          });
+        }
+      });
+
+      tab.on("close", function () {     // When the tab is closed we know autoshot is done, so return the URL
         console.log('completed processing BACK'.replace('BACK', backendUrl));
         response.setStatusLine("1.1", 200, "OK");
         response.write(contentServerString + backendUrl + '\n');

--- a/addon/lib/headless.js
+++ b/addon/lib/headless.js
@@ -121,7 +121,7 @@ function handleReadableRequest(request, response) {
           });
           worker.port.on("done", function () { // When the worker emits done, wait a bit then fire autoshot
             console.log('readability should be finished');
-            sleep(500000);
+            sleep(prefs.readableSleep); // Sleep is required because if you fire autoShot immediately the DOM comes up empty
             autoShot(tab, backend, backendUrl);
           });
         }

--- a/addon/lib/headless.js
+++ b/addon/lib/headless.js
@@ -130,7 +130,7 @@ function handleReadableRequest(request, response) {
       tab.on("close", function () {     // When the tab is closed we know autoshot is done, so return the URL
         console.log('completed processing BACK'.replace('BACK', backendUrl));
         response.setStatusLine("1.1", 200, "OK");
-        response.write(contentServerString + backendUrl + '\n');
+        response.write(backendUrl + '\n');
         response.finish();
       });
     }

--- a/addon/package.json
+++ b/addon/package.json
@@ -40,6 +40,13 @@
       "value": "localhost"
     },
     {
+      "name": "readableSleep",
+      "title": "HTTP server: sleep variable",
+      "description": "Amount of time (in ms) to sleep when handling a readable request",
+      "type": "integer",
+      "value": 200
+    },
+    {
       "name": "inlineCss",
       "title": "inline CSS",
       "description": "EXPERIMENTAL: instead of including CSS files, inline only necessary CSS in style tags",


### PR DESCRIPTION
Adds a `/readable/` route to the HTTP server.

Functionally speaking, it does the following:
1. Opens the url in a tab
2. When the tab has loaded the first time, clicks the readable button in the firefox UI (for this reason this route is only compatible with pages that are compatible with firefox's readability mode)
3. The second time the page loads it removes the readability mode sidebar
4. Waits a short time to ensure removal of sidebar has resolved (see headless.js L124)
5. Fires autoShot on the open tab