### PR TITLE
r?fzzzy Admin page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ addon_js_dest := $(addon_js_source:%=build/%)
 # they exist:
 shoot_panel_dependencies = $(shell if [[ -e build/shoot-panel-dependencies.txt ]] ; then cat build/shoot-panel-dependencies.txt ; fi)
 clientglue_dependencies = $(shell if [[ -e build/clientglue-dependencies.txt ]] ; then cat build/clientglue-dependencies.txt ; fi)
+admin_dependencies = $(shell if [[ -e build/admin-dependencies.txt ]] ; then cat build/admin-dependencies.txt ; fi)
 
 ## General transforms:
 # These cover standard ways of building files given a source
@@ -175,7 +176,7 @@ build/addon/lib/httpd.jsm: addon/lib/httpd.jsm
 	cp $< $@
 
 addon: npm $(data_dest) $(vendor_dest) $(lib_dest) $(sass_addon_dest) $(imgs_addon_dest) $(static_addon_dest) $(shared_addon_dest) build/addon/data/panel-bundle.js build/addon/package.json build/addon/lib/httpd.jsm
- 
+
 xpi: build/mozilla-pageshot.xpi build/mozilla-pageshot.update.rdf
 
 ## Server related rules:
@@ -195,6 +196,12 @@ build/server/static/js/server-bundle.js: $(clientglue_dependencies)
 	browserify --list -e ./build/server/clientglue.js | sed "s!$(shell pwd)/!!g" | grep -v build-time > build/clientglue-dependencies.txt
 	browserify -o $@ -e ./build/server/clientglue.js ./build/server/shotindexglue.js
 
+build/server/static/js/admin-bundle.js: $(admin_dependencies) $(server_dest)
+	@mkdir -p $(@D)
+	# Generate/save dependency list:
+	browserify --list -e ./build/server/pages/admin/controller.js | sed "s!$(shell pwd)/!!g" | grep -v build-time > build/admin-dependencies.txt
+	browserify -o $@ -e ./build/server/pages/admin/controller.js
+
 build/server/export-shots.sh: server/src/export-shots.sh
 	@mkdir -p $(@D)
 	cp -p $< $@
@@ -206,7 +213,7 @@ build/server/build-time.js: homepage $(server_dest) $(shared_server_dest) $(sass
 	@mkdir -p $(@D)
 	./bin/_write_build_time > build/server/build-time.js
 
-server: npm build/server/build-time.js build/server/static/js/server-bundle.js
+server: npm build/server/build-time.js build/server/static/js/server-bundle.js build/server/static/js/admin-bundle.js
 
 ## Homepage related rules:
 

--- a/server/src/linker.js
+++ b/server/src/linker.js
@@ -2,6 +2,7 @@ const git = require('git-rev');
 
 let gitRevision;
 
+// FIXME: move this to server.js or somewhere else, so git-rev doesn't get included in the bundle
 exports.init = function () {
   return new Promise((resolve, reject) => {
     git.long((rev) => {

--- a/server/src/pages/admin/controller.js
+++ b/server/src/pages/admin/controller.js
@@ -1,0 +1,36 @@
+/* browser: true */
+/* globals window, XMLHttpRequest, alert */
+
+const page = require("./page").page;
+
+let model;
+
+exports.launch = function (m) {
+  model = m;
+  render();
+};
+
+function render() {
+  page.render(model);
+}
+
+exports.onChangeLastShotTime = function (days) {
+  model.lastShotTimeDays = days;
+  model.lastShotCount = '\u2B6E';
+  render();
+  let req = new XMLHttpRequest();
+  req.open("GET", `./api/recent/lastShotCount?lastShotTimeDays=${encodeURIComponent(days)}`);
+  req.onload = function () {
+    if (req.status == 200) {
+      let data = JSON.parse(req.responseText);
+      model.lastShotTimeDays = days;
+      model.lastShotCount = data.count;
+      render();
+    } else {
+      alert("Failed: " + req.status);
+    }
+  };
+  req.send();
+};
+
+window.controller = exports;

--- a/server/src/pages/admin/model.js
+++ b/server/src/pages/admin/model.js
@@ -1,0 +1,26 @@
+const db = require("../../db");
+
+exports.lastShotCount = function (seconds) {
+  return db.select(
+    `SELECT COUNT(DISTINCT deviceid) AS shotcount
+     FROM data
+     WHERE created >= NOW() - ($1 || ' SECONDS')::INTERVAL`,
+    [seconds]
+  ).then(function (rows) {
+    return rows[0].shotcount;
+  });
+};
+
+exports.secondsInDay = 60*60*24;
+
+exports.createModel = function (req) {
+  let model = {
+    title: "Admin",
+    lastShotTimeDays: 7
+  };
+  let secs = model.lastShotTimeDays * exports.secondsInDay;
+  return exports.lastShotCount(secs).then((lastShotCount) => {
+    model.lastShotCount = lastShotCount;
+    return model;
+  });
+};

--- a/server/src/pages/admin/page.js
+++ b/server/src/pages/admin/page.js
@@ -1,0 +1,5 @@
+const { Page } = require("../../reactruntime");
+
+exports.page = new Page({
+  dir: __dirname
+});

--- a/server/src/pages/admin/server.js
+++ b/server/src/pages/admin/server.js
@@ -1,0 +1,69 @@
+const express = require("express");
+const users = require("../../users");
+const reactrender = require("../../reactrender");
+
+let app = express();
+
+exports.app = app;
+
+// FIXME: this should be an FxA id, but due to a bug we're using device IDs
+let authorizedAccountIds = ['anon63daec35-fb29-8d49-ac6f-af7763523c0a'];
+
+app.use(function (req, res, next) {
+  if (! req.deviceId) {
+    res.status(403).send(`
+      <html>
+        <head>
+          <title>Must login</title>
+        </head>
+        <body>
+          You must be using the add-on
+        </body>
+      </html>
+    `);
+    return;
+  }
+  users.accountIdForDeviceId(req.deviceId).then((accountId) => {
+    // FIXME: terrible workaround for fxa account not being stored:
+    accountId = req.deviceId;
+    if (! accountId) {
+      res.status(403).send(`
+        <html>
+          <head><title>Login already</title></head>
+          <body>
+            You must login with a Firefox Account.  Try from the <a href="/shots">shots page</a>.
+          </body>
+        </html>
+      `);
+      return;
+    }
+    if (authorizedAccountIds.indexOf(accountId) === -1) {
+      res.type("txt").status(403).send(
+        `Go away ${req.deviceId}`);
+      return;
+    }
+    next();
+  }).catch((err) => {
+    req.type("txt").status(500).send(`Error:\n${err}\n${err.stack}`);
+  });
+});
+
+app.get("/", function (req, res) {
+  if (req.originalUrl == "/admin") {
+    // We want a trailing slash
+    res.redirect("/admin/");
+    return;
+  }
+  const page = require("./page").page;
+  reactrender.render(req, res, page);
+});
+
+app.get("/api/recent/lastShotCount", function (req, res) {
+  let days = parseFloat(req.query.lastShotTimeDays);
+  const model = require("./model");
+  model.lastShotCount(days * model.secondsInDay).then((count) => {
+    res.send({count: count});
+  }).catch((err) => {
+    res.type("txt").status(500).send("Error: " + err);
+  });
+});

--- a/server/src/pages/admin/view.js
+++ b/server/src/pages/admin/view.js
@@ -1,0 +1,40 @@
+/* globals window */
+const reactruntime = require("../../reactruntime");
+const React = require("react");
+
+class Head extends React.Component {
+
+  render() {
+    return (
+      <reactruntime.HeadTemplate {...this.props}>
+        <script src={this.props.staticLink("js/admin-bundle.js")}></script>
+        <link rel="stylesheet" href={this.props.staticLink("css/admin.css")} />
+      </reactruntime.HeadTemplate>
+    );
+  }
+
+}
+
+class Body extends React.Component {
+  render() {
+    return (
+      <reactruntime.BodyTemplate {...this.props}>
+        <h1>Admin</h1>
+        <fieldset>
+          <legend>Recent users:</legend>
+          <div>
+            Users with shots made in the last <input type="number" ref="lastShotTime" onChange={this.onChangeLastShotTime.bind(this)} defaultValue={this.props.lastShotTimeDays} /> days: <strong>{this.props.lastShotCount}</strong>
+          </div>
+        </fieldset>
+      </reactruntime.BodyTemplate>
+    );
+  }
+
+  onChangeLastShotTime(event) {
+    let value = parseFloat(this.refs.lastShotTime.getDOMNode().value);
+    window.controller.onChangeLastShotTime(value);
+  }
+}
+
+exports.HeadFactory = React.createFactory(Head);
+exports.BodyFactory = React.createFactory(Body);

--- a/server/src/reactrender.js
+++ b/server/src/reactrender.js
@@ -1,0 +1,36 @@
+const { addReactScripts } = require("./reactutils");
+const React = require("react");
+const { getGitRevision } = require("./linker");
+
+exports.render = function (req, res, page) {
+  console.log("rendering");
+  let modelModule = require("./" + page.modelModuleName);
+  let viewModule = require("./" + page.viewModuleName);
+  modelModule.createModel(req).then((model) => {
+    model = {
+      backend: req.backend,
+      gitRevision: getGitRevision(),
+      ...model
+    };
+    let serverModel = {
+      staticLink: req.staticLink,
+      ...model
+    };
+    let head = React.renderToStaticMarkup(viewModule.HeadFactory(serverModel));
+    let body = React.renderToString(viewModule.BodyFactory(serverModel));
+    let doc = `
+    <html>
+      ${head}
+      <body>
+        <div id="react-body-container">
+          ${body}
+        </div>
+      </body></html>
+    `.trim();
+    // FIXME: we should just inline the addReactScripts functionality in this function:
+    doc = addReactScripts(doc, `controller.launch(${JSON.stringify(model)});`);
+    res.send(doc);
+  }).catch((err) => {
+    res.type("txt").status(500).send("Error: " + err + "\n" + err.stack);
+  });
+};

--- a/server/src/reactruntime.js
+++ b/server/src/reactruntime.js
@@ -1,0 +1,90 @@
+/* globals document */
+
+const React = require("react");
+const linker = require("./linker");
+
+exports.HeadTemplate = class HeadTemplate extends React.Component {
+
+  render() {
+    // FIXME: this should probably include some standard CSS or other boilerplate
+    // FIXME: should also include (at least optionally) GA
+    return (
+      <head>
+        <meta charSet="UTF-8" />
+        <title>{this.props.title}</title>
+        {this.props.children}
+      </head>
+    );
+  }
+
+};
+
+exports.BodyTemplate = class Body extends React.Component {
+
+  render() {
+    return (
+      <div>
+        {this.props.children}
+      </div>
+    );
+  }
+
+};
+
+exports.Page = class Page {
+  constructor(options) {
+    for (let name in options) {
+      if (! this.ATTRS.includes(name)) {
+        throw new Error("Invalid attribute to Page: " + name);
+      }
+      let value = options[name];
+      this[name] = value;
+    }
+  }
+
+  set dir(val) {
+    if (val.startsWith("/")) {
+      if (! val.startsWith(__dirname)) {
+        throw new Error("Unknown directory for page: " + val + " (not " + __dirname + ")");
+      }
+      val = val.substr(__dirname.length).replace(/^\/+/, "");
+    }
+    val = val.replace(/\/+$/, "");
+    this._dir = val;
+  }
+
+  render(model) {
+    if (! model.staticLink) {
+      linker.setGitRevision(model.gitRevision);
+      model.staticLink = linker.staticLink;
+    }
+    let body = this.BodyFactory(model);
+    React.render(
+      body,
+      document.getElementById("react-body-container"));
+  }
+
+  get dir() {
+    return this._dir;
+  }
+
+  get modelModuleName() {
+    return this.dir + "/model";
+  }
+
+  get viewModuleName() {
+    return this.dir + "/view";
+  }
+
+  get BodyFactory() {
+    // FIXME: this doesn't work well with browserify, hence a static require()
+    // (which could appear anywhere in the file)
+    require("./pages/admin/view");
+    return require("./" + this.viewModuleName).BodyFactory;
+  }
+
+};
+
+exports.Page.prototype.ATTRS = `
+dir
+`.split(/\s+/g);

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -619,7 +619,7 @@ app.post('/api/fxa-oauth/token', function (req, res, next) {
       res.send({
         access_token: accessToken
       });
-    });
+    }).catch(next);
   }).catch(next);
 });
 
@@ -635,6 +635,8 @@ app.use(function (err, req, res, next) {
   }
   errorResponse(res, "General error:", err);
 });
+
+app.use("/admin", require("./pages/admin/server").app);
 
 const contentApp = express();
 

--- a/server/src/users.js
+++ b/server/src/users.js
@@ -72,6 +72,21 @@ exports.updateLogin = function (deviceId, data) {
   ).then(rowCount => !! rowCount);
 };
 
+exports.accountIdForDeviceId = function (deviceId) {
+  if (! deviceId) {
+    throw new Error("No deviceId given");
+  }
+  return db.select(
+    `SELECT accountid FROM devices WHERE id = $1`,
+    [deviceId]
+  ).then((rows) => {
+    if (! rows.length) {
+      return null;
+    }
+    return rows[0].accountid;
+  });
+};
+
 exports.setState = function (deviceId, state) {
   return db.insert(
     `INSERT INTO states (state, deviceid)

--- a/server/views-docs.md
+++ b/server/views-docs.md
@@ -1,0 +1,159 @@
+## Views
+
+This documents the structure-in-progress for handling views in PageShot, and with isomorphic React rendering generally.
+
+### Goals
+
+We want:
+
+1. To keep the dependency graph separated out for the browser and the server.  Things to be used in the browser should never depend on the server or even refer to it (so server-oriented code isn't bundled).  Things to be used on the server should not import browser-oriented code.
+2. Some code should be shared between server and browser.
+3. We want to gracefully handle the *model* between server and browser.
+4. Only the server needs to know how to *instantiate* the model.
+5. Only the browser needs to know how to *update* the model (the server will simply reinstantiate).
+6. The model should represent everything we need to know about rendering the page.
+  7. Except for some transient states created for the purposes of user-input.
+
+### Components
+
+There are five components of a typical page:
+
+#### 1. The declaration (`page.js`):
+
+This is declarative, and represents the "page", essentially all the components listed below.  It is usable from the browser and client.
+
+Must export `page` (an instance of `reactruntime.Page`)
+
+#### 2. The server model (`model.js`):
+
+This instantiates the model based on a request.  The model is JSONable.  It also implements data-oriented routines, such as page-specific database queries.
+
+This must export `createModel(req)`.  This should look like:
+
+```javascript
+exports.createModel = function (req) {
+  return db.doSomething().then((result) =>
+    return {
+      someValue: result
+      title: "A page"
+    };
+  };
+};
+```
+
+Besides `title` nothing is required in the model.
+
+#### 3. The server controller (`server.js`):
+
+This handles routing and responding to the initial request.  This instantiates the model (from `model.js`) and uses that to render the page.  This also implements any API endpoints that are used by the browser to update data (though the actual updating typically will take place in `model.js`).
+
+This must export `app` (an Express application that will be mounted).
+
+#### 4. The view (`view.js`):
+
+This is shared between the server and the browser.  It is a module that exports React components for the head and body.  It has even handlers; these handlers should parse any input (e.g., extract the value of a form field), but to *do* anything they simply call `controller.onSomething(value)`.
+
+This must export `HeadFactory` and `BodyFactory` (see `reactruntime.HeadTemplate` for how these should work).
+
+#### 5. The browser controller (`controller.js`):
+
+This handles events, managing the model on the browser side, making requests to APIs, and generally all the logic in the browser.  It effectively manages the model on the browser (there is not a separate module for this).
+
+This must *assign* `window.controller` (instead of exporting, like `window.controller = exports`), and must export `launch(model)`.  The basic form of the code should be:
+
+```javascript
+const page = require("./page").page;
+
+let model;
+
+exports.launch = function (m) {
+  model = m;
+  render();
+};
+
+function render() {
+  page.render(model);
+}
+
+exports.onSomething = function (value) {
+  model.something = value;
+  render();
+};
+
+window.controller = exports;
+```
+
+### Helpers/glue
+
+To put these all together we have several modules:
+
+#### `reactruntime`
+
+This is used primarily in the browser, though it is also used on the server.
+
+##### `reactruntime.Page`
+
+This class is what you instantiate to get `page.page`.  Currently it is fairly minimal:
+
+```javascript
+exports.page = new Page({
+  dir: __dirname
+});
+```
+
+Everything else is implied by the standard module names in the directory.
+
+##### `reactruntime.HeadTemplate` / `reactruntime.BodyTemplate`
+
+This is the component you should used in your own `view.HeadFactory`:
+
+```javascript
+const {HeadTemplate, BodyTemplate} = require("../../reactruntime");
+class Head extends React.Component {
+  render() {
+    return (
+      <HeadTemplate {...this.props}>
+        <script src={this.props.staticLink("js/controller.js")}></script>
+        <link href={this.props.staticLink("css/mypage.css")} />
+      </HeadTemplate>
+    );
+  }
+}
+class Body extends React.Component {
+  render() {
+    return (
+      <BodyTemplate {...this.props}>
+        Some markup
+      </BodyTemplate>
+    );
+  }
+}
+
+exports.HeadFactory = React.createFactory(Head);
+exports.BodyFactory = React.createFactory(Body);
+```
+
+#### `reactrender.render`
+
+This is used on the server side, like:
+
+```javascript
+const reactrender = require("reactrender");
+
+app.get("/something", function (req, res) {
+  const page = require("./page").page;
+  reactrender.render(req, res, page);
+});
+```
+
+This handles calling the model instantiation, instantiating the views, and gluing that all together into a page.
+
+It also sets up `this.props.staticLink` on the client and server.
+
+### Making
+
+The make process is kind of crude, mostly because how browserify fits in is pretty crude.  A problem with respect to browserify is that `require()` with dynamic arguments does not work well (even if the module is actually available in the bundle).  You'll note a superfluous require in `reactruntime` to work around this problem.
+
+Also each browserify bundle is independently enumerated and handled in the `Makefile`.  
+
+I'm thinking of scanning for `server/src/pages/*/page.js` and generating Makefile statements from that, but that makes me somewhat sad.

--- a/static/css/admin.scss
+++ b/static/css/admin.scss
@@ -1,0 +1,3 @@
+body {
+  font-family: sans-serif;
+}


### PR DESCRIPTION
This pull request should be closed first: #921 (I didn't separate things out)

This adds an admin page.  There's a problem with FxA, so right now there's a hardcoded list of deviceIds that can access the page.

I also implemented a new pattern for isomorphic pages, described in [a document](https://github.com/mozilla-services/pageshot/blob/admin-page/server/views-docs.md) – the idea being that we could use this for other pages on the site, but it would be easiest to experiment on the admin page.  The dynamic imports make me sad, but otherwise I feel okay about the pattern.