### PR TITLE
Fix a few ESLint errors due to exports oddness

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,8 @@
 addon/data/raven.js
 addon/data/vendor
-static/vendor
+addon/lib/notificationbox.js
 static/homepage/js
+static/vendor
 /scratch
 /Profile
 /build

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,9 +11,15 @@ parserOptions:
   ecmaFeatures:
     jsx: true
 
+plugins:
+  - react
+
 root: true
 
 rules:
+  react/jsx-uses-react: 1
+  react/jsx-uses-vars: 1
+
   comma-dangle: 0
   no-console: 0
   no-unused-vars: [2, {vars: all, args: none}]

--- a/addon/.eslintrc
+++ b/addon/.eslintrc
@@ -1,0 +1,2 @@
+env:
+  browser: true

--- a/addon/data/annotate-position.js
+++ b/addon/data/annotate-position.js
@@ -1,7 +1,7 @@
 /** Takes a pixel position and gives a "full" location using element offsets */
 /* exported annotatePosition */
 
-function annotatePosition(pos) {
+function annotatePosition(pos) { // eslint-disable-line no-unused-vars
   function findElement(x, y, offsetX, offsetY) {
     let element = document.elementFromPoint(x - window.pageXOffset + offsetX, y - window.pageYOffset + offsetY);
     if ((! element) || (! element.id)) {

--- a/addon/data/error-utils.js
+++ b/addon/data/error-utils.js
@@ -12,7 +12,7 @@ function unhandled(error) {
 function getFilename() {
   try {
     return FILENAME;
-  } catch (e) {
+  } catch (e) { // eslint-disable-line no-empty
   }
   return "unknown";
 }

--- a/addon/data/extractor-worker.js
+++ b/addon/data/extractor-worker.js
@@ -1,5 +1,7 @@
-/* globals Readability, watchFunction, document, console, location, self */
 /* exported FILENAME, extractorWorker */
+
+/* globals Readability, watchFunction, document, console, location, self */
+
 /** extractor-worker is a content worker that is attached to a page when
     making a shot
 
@@ -7,11 +9,11 @@
     */
 
 // Set for use in error messages:
-var FILENAME = "extractor-worker.js";
+var FILENAME = "extractor-worker.js"; // eslint-disable-line no-unused-vars
 
 var isChrome = false;
 
-const extractorWorker = (function () {
+const extractorWorker = (function () { // eslint-disable-line no-unused-vars
   /** Extracts data:
       - Gets the Readability version of the page (`.readable`)
       - Finds images in roughly the preferred order (`.images`)

--- a/addon/data/framescripts/add-ids.js
+++ b/addon/data/framescripts/add-ids.js
@@ -3,7 +3,7 @@
 
 var isChrome = false;
 
-const addIds = (function () {
+const addIds = (function () { // eslint-disable-line no-unused-vars
   let exports = {};
 
   var idCount = 0;

--- a/addon/data/framescripts/make-static-html.js
+++ b/addon/data/framescripts/make-static-html.js
@@ -15,7 +15,7 @@
 
 var isChrome = false;
 
-const makeStaticHtml = (function () {
+const makeStaticHtml = (function () { // eslint-disable-line no-unused-vars
   let exports = {};
 
   let uuidGenerator;

--- a/addon/data/framescripts/screenshot.js
+++ b/addon/data/framescripts/screenshot.js
@@ -3,6 +3,7 @@
     This is written to be handled by `lib/framescripter.js`
     */
 
+/* globals addMessageListener, sendAsyncMessage, content */
 
 // FIXME: this is a hack to take a shot of the iframe in the viewer
 // instead of the container

--- a/addon/data/selector-snapping.js
+++ b/addon/data/selector-snapping.js
@@ -1,5 +1,5 @@
 /* exported snapping */
-const snapping = (function () {
+const snapping = (function () { // eslint-disable-line no-unused-vars
   let exports = {};
 
   let xSnaps = [];
@@ -88,7 +88,7 @@ const snapping = (function () {
     var index = Math.floor(snapsLength/2);
     var less = 0;
     var more = snapsLength;
-    while (true) {
+    while (true) { // eslint-disable-line no-constant-condition
       if (snaps[index] <= pos && snaps[index+1] >= pos) {
         break;
       }

--- a/addon/data/selector-ui.js
+++ b/addon/data/selector-ui.js
@@ -3,7 +3,7 @@
 
 var isChrome = false;
 
-const ui = (function () {
+const ui = (function () { // eslint-disable-line no-unused-vars
   let exports = {};
 
   // The <body> tag itself can have margins and offsets, which need to be used when

--- a/addon/data/selector-util.js
+++ b/addon/data/selector-util.js
@@ -1,6 +1,6 @@
 /* exported util */
 
-const util = (function () {
+const util = (function () { // eslint-disable-line no-unused-vars
   let exports = {};
 
   /** Removes a node from its document, if it's a node and the node is attached to a parent */

--- a/addon/lib/helperworker.js
+++ b/addon/lib/helperworker.js
@@ -7,12 +7,10 @@
     */
 
 var self = require("sdk/self");
-var simplePrefs = require('sdk/simple-prefs');
-var { captureTab } = require("./screenshot");
+var simplePrefs = require("sdk/simple-prefs");
 var pageMod = require("sdk/page-mod");
 var clipboard = require("sdk/clipboard");
 var notifications = require("sdk/notifications");
-var { XMLHttpRequest } = require("sdk/net/xhr");
 const shotstore = require("./shotstore");
 const { watchFunction, watchWorker } = require("./errors");
 const user = require("./user");

--- a/addon/lib/main.js
+++ b/addon/lib/main.js
@@ -13,11 +13,11 @@ require("sdk/preferences/service").set("javascript.options.strict", false);
 const self = require("sdk/self");
 const tabs = require("sdk/tabs");
 const shooter = require("./shooter");
-const { prefs } = require('sdk/simple-prefs');
+const { prefs } = require("sdk/simple-prefs");
 const helperworker = require("./helperworker");
-const { ActionButton } = require('sdk/ui/button/action');
+const { ActionButton } = require("sdk/ui/button/action");
 const { watchFunction } = require("./errors");
-const {Cu, Cc, Ci} = require("chrome");
+const { Cu, Cc, Ci } = require("chrome");
 const winutil = require("sdk/window/utils");
 const req = require("./req");
 const { setTimeout } = require("sdk/timers");
@@ -30,7 +30,7 @@ require("./headless").init();
 
 Cu.import("resource:///modules/UITour.jsm");
 
-let loadReason = null;
+let loadReason = null; // eslint-disable-line no-unused-vars
 let initialized = false;
 
 function getNotificationBox(browser) {

--- a/addon/lib/shooter.js
+++ b/addon/lib/shooter.js
@@ -23,7 +23,7 @@ const { randomString } = require("./randomstring");
 const { setTimeout, clearTimeout } = require("sdk/timers");
 const shotstore = require("./shotstore");
 
-let shouldShowTour = false;
+let shouldShowTour = false; // eslint-disable-line no-unused-vars
 
 exports.showTourOnNextLinkClick = function() {
   shouldShowTour = true;

--- a/addon/lib/user.js
+++ b/addon/lib/user.js
@@ -29,7 +29,7 @@ exports.isInitialized = function () {
   return initialized;
 };
 
-let cachedBackend, cachedReason;
+let cachedBackend, cachedReason; // eslint-disable-line no-unused-vars
 
 exports.initialize = function (backend, reason) {
   // This lets us retry initialize() with no parameters later if necessary:

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -10,7 +10,7 @@ for (let permission of manifest.permissions) {
 }
 backend = backend.replace(/\/*$/, "");
 let registrationInfo;
-let initialized = false;
+let initialized = false; // eslint-disable-line no-unused-vars
 const STORAGE_LIMIT = 100;
 const TIME_LIMIT = 1000 * 60 * 60 * 24 * 30; // 30 days
 

--- a/chrome-extension/chrome-shooter.js
+++ b/chrome-extension/chrome-shooter.js
@@ -3,7 +3,7 @@
 /* globals document, setTimeout, location */
 /* exported chromeShooter */
 
-const chromeShooter = (function () {
+const chromeShooter = (function () { // eslint-disable-line no-unused-vars
   let exports = {};
 
   const RANDOM_STRING_LENGTH = 16;

--- a/chrome-extension/randomstring.js
+++ b/chrome-extension/randomstring.js
@@ -1,7 +1,7 @@
 /** Similar to addon/lib/randomstring, but uses Math.random */
 /* exported randomString */
 
-function randomString(length, chars) {
+function randomString(length, chars) { // eslint-disable-line no-unused-vars
   let randomStringChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
   chars = chars || randomStringChars;
   let result = "";

--- a/chrome-extension/url-domain.js
+++ b/chrome-extension/url-domain.js
@@ -3,10 +3,10 @@
 /** Returns the domain of a URL, but safely and in ASCII; URLs without domains
     (such as about:blank) return the scheme, Unicode domains get stripped down
     to ASCII */
-function urlDomainForId(location) {
+function urlDomainForId(location) { // eslint-disable-line no-unused-vars
   let domain = location.hostname;
   if (domain) {
-    if (domain.indexOf(":") != -1) {
+    if (domain.indexOf(":") !== -1) {
       domain = domain.replace(/:.*/, "");
     }
   } else {
@@ -15,7 +15,7 @@ function urlDomainForId(location) {
       domain = "unknown";
     }
   }
-  if (domain.search(/^[a-z0-9.\-]+$/i) == -1) {
+  if (domain.search(/^[a-z0-9.\-]+$/i) === -1) {
     // Probably a unicode domain; we could use punycode but it wouldn't decode
     // well in the URL anyway.  Instead we'll punt.
     domain = domain.replace(/[^a-z0-9.\-]/ig, "");

--- a/chrome-extension/uuid.js
+++ b/chrome-extension/uuid.js
@@ -1,9 +1,10 @@
 /* exported makeUuid */
 
 // From http://stackoverflow.com/questions/105034/create-guid-uuid-in-javascript
-function makeUuid() {
+function makeUuid() { // eslint-disable-line no-unused-vars
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+    var r = Math.random()*16 | 0,
+      v = c === 'x' ? r : (r & 0x3 | 0x8);
     return v.toString(16);
   });
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "wreck": "5.5.1"
   },
   "devDependencies": {
-    "eslint": "3.0.0"
+    "eslint": "3.0.0",
+    "eslint-plugin-react": "5.2.2"
   },
   "homepage": "https://pageshot.dev.mozaws.net",
   "license": "MPL-2.0",

--- a/server/src/clientglue.js
+++ b/server/src/clientglue.js
@@ -129,7 +129,7 @@ function refreshHash() {
   if (match) {
     clipId = decodeURIComponent(match[1]);
   }
-  let source = "change-clip";
+  let source = "change-clip"; // eslint-disable-line no-unused-vars
   match = (/source=([^&]+)/).exec(location.hash);
   if (match) {
     source = decodeURIComponent(match[1]);

--- a/server/src/ga-activation.js
+++ b/server/src/ga-activation.js
@@ -4,8 +4,6 @@
    Hashes page names
    */
 
-const React = require("react");
-
 const dntJs = `
 // Copied from https://github.com/mozilla/bedrock/blob/22079855caeb660724319f735de51e3a7472a50f/media/js/base/dnt-helper.js
 function _dntEnabled(dnt, ua) {

--- a/server/src/views/frame.js
+++ b/server/src/views/frame.js
@@ -2,7 +2,7 @@
 
 const React = require("react");
 const { getGitRevision } = require("../linker");
-const { ProfileButton } = require("./profile");
+// const { ProfileButton } = require("./profile");
 const { addReactScripts } = require("../reactutils");
 const { gaActivation } = require("../ga-activation");
 

--- a/static/js/parent-helper.js
+++ b/static/js/parent-helper.js
@@ -1,9 +1,7 @@
-/*jslint browser: true */
-/*global console,CONTENT_HOSTING_ORIGIN */
+/* global console,CONTENT_HOSTING_ORIGIN */
 
-let loaded = false,
-  height = null,
-  resolveChildReference;
+let loaded = false;
+let height = null;
 
 function sendToChild(message) {
   if (! sendToChild.childReference) {


### PR DESCRIPTION
#### Current output:

```sh
$ npm run lint

> pageshot@0.0.1 lint /Users/pdehaan/dev/github/mozilla-services/pageshot
> eslint .


/Users/pdehaan/dev/github/mozilla-services/pageshot/addon/lib/main.js
  186:5  error  'hotKey' is defined but never used  no-unused-vars

/Users/pdehaan/dev/github/mozilla-services/pageshot/server/src/views/frame.js
  1:16  error  'Raven' is defined but never used  no-unused-vars

✖ 2 problems (2 errors, 0 warnings)
```

Fixes #1195


