### PR TITLE
Add sass-lint workflow

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,26 @@
+files:
+  include: ./static/css/*.scss
+
+options:
+  merge-default-rules: true
+
+rules:
+  force-attribute-nesting: 0
+  force-element-nesting: 0
+  force-pseudo-nesting: 0
+  hex-length: 2
+  hex-notation: [2, {style: lowercase}]
+  leading-zero: [2, {include: true}]
+  no-color-keywords: 2
+  no-color-literals: 0
+  no-css-comments: 0
+  no-ids: 0
+  no-important: 1
+  no-qualifying-elements: 0
+  no-url-protocols: 0
+  property-sort-order: 0
+  quotes: [2, {style: double}]
+  single-line-per-selector: 2
+  space-after-comma: 2
+  url-quotes: 2
+  zero-unit: 2

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "devDependencies": {
     "eslint": "3.0.0",
-    "eslint-plugin-react": "5.2.2"
+    "eslint-plugin-react": "5.2.2",
+    "sass-lint": "1.8.2"
   },
   "homepage": "https://pageshot.dev.mozaws.net",
   "license": "MPL-2.0",
@@ -54,6 +55,7 @@
   },
   "scripts": {
     "lint": "eslint .",
+    "sass": "sass-lint -v -q",
     "test": "echo \"Error: no test specified\" && exit 1"
   }
 }

--- a/static/css/content.scss
+++ b/static/css/content.scss
@@ -2,5 +2,5 @@
   position: absolute;
   pointer-events: none;
   z-index: 10000;
-  border: 3px solid rgba(0, 149, 221, 0.5);
+  border: 3px solid rgba(#0095dd, 0.5);
 }

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -205,7 +205,7 @@ $overlay-z-index: 900000;
 
 .pageshot-bghighlight {
   position: absolute;
-  background-color: rgba(50, 50, 50, 0.5);
+  background-color: rgba(#323232, 0.5);
   pointer-events: none;
   z-index: 1000;
 }
@@ -262,9 +262,9 @@ $overlay-z-index: 900000;
   width: 40px;
   height: 40px;
   border-radius: 20px;
-  border: 1px solid rgba(255, 255, 0, 0.5);
+  border: 1px solid rgba(#ff0, 0.5);
   z-index: $overlay-z-index + 1000;
-  background-image: radial-gradient(20px at 50% 50%, rgba(255, 255, 0, 0.1), rgba(255, 255, 0, 0.5));
+  background-image: radial-gradient(20px at 50% 50%, rgba(#ff0, 0.1), rgba(#ff0, 0.5));
   animation-name: pageshot-pulse;
   animation-duration: 1s;
   animation-fill-mode: both;
@@ -330,8 +330,8 @@ $overlay-z-index: 900000;
 .pageshot-myshots-reminder > .pageshot-panel {
   background-clip: padding-box;
   background-color: #fcfcfc;
-  border: 1px solid rgba(24, 26, 27, 0.2);
-  box-shadow: 0 3px 5px rgba(24, 26, 27, 0.1), 0 0 7px rgba(24, 26, 27, 0.1);
+  border: 1px solid rgba(#181a1b, 0.2);
+  box-shadow: 0 3px 5px rgba(#181a1b, 0.1), 0 0 7px rgba(#181a1b, 0.1);
   box-sizing: content-box;
   color: #222426;
   cursor: default;

--- a/static/css/inline-selection.scss
+++ b/static/css/inline-selection.scss
@@ -1,15 +1,20 @@
 // This is how far outside the selection the mover target extends:
 $mover-outer: 10px;
+
 // And this is how far inside the selection it extends:
 $mover-inner: 40px;
+
 // This is the size of the little blue handles:
 $handle-size: 25px;
+
 // And the size when the selection is "small":
 $handle-size-small: 10px;
+
 // This is how far out of the box the handles go:
-$handle-outside-extent: 0px;
+$handle-outside-extent: 0;
+
 // And some calculated values based on these that will be used below:
-$handle-mover-offset: $mover-outer - ($handle-outside-extent / 2);
+$handle-mover-offset: $mover-outer - $handle-outside-extent / 2;
 $mover-size: $mover-outer + $mover-inner;
 $overlay-z-index: 900000;
 
@@ -44,89 +49,98 @@ $overlay-z-index: 900000;
   pointer-events: auto;
 }
 
-.pageshot-highlight, .pageshot-mover-target {
+.pageshot-highlight,
+.pageshot-mover-target {
   background-color: transparent;
   background-image: none;
 }
 
-.pageshot-mover-target, .pageshot-bghighlight {
-  border: none;
+.pageshot-mover-target,
+.pageshot-bghighlight {
+  border: 0;
 }
 
 .pageshot-mover-target.pageshot-topLeft {
   cursor: nwse-resize;
-  top: - $mover-outer;
-  left: - $mover-outer;
+  top: -$mover-outer;
+  left: -$mover-outer;
   width: $mover-size;
   height: $mover-size;
 }
+
 .pageshot-mover-target.pageshot-top {
   cursor: ns-resize;
-  top: - $mover-outer;
+  top: -$mover-outer;
   left: 0;
   width: 100%;
   height: $mover-size;
   // It will be too wide, but this will place it below topLeft/etc:
   z-index: 4;
 }
+
 .pageshot-mover-target.pageshot-topRight {
   cursor: nesw-resize;
-  top: - $mover-outer;
-  right: - $mover-outer;
+  top: -$mover-outer;
+  right: -$mover-outer;
   height: $mover-size;
   width: $mover-size;
 }
+
 .pageshot-mover-target.pageshot-left {
   cursor: ew-resize;
   top: 0;
-  left: - $mover-outer;
+  left: -$mover-outer;
   height: 100%;
   width: $mover-size;
   z-index: 4;
 }
+
 .pageshot-mover-target.pageshot-right {
   cursor: ew-resize;
   top: 0;
-  right: - $mover-outer;
+  right: -$mover-outer;
   height: 100%;
   width: $mover-size;
   z-index: 4;
 }
+
 .pageshot-mover-target.pageshot-bottomLeft {
   cursor: nesw-resize;
-  left: - $mover-outer;
-  bottom: - $mover-outer;
+  left: -$mover-outer;
+  bottom: -$mover-outer;
   width: $mover-size;
   height: $mover-size;
 }
+
 .pageshot-mover-target.pageshot-bottom {
   cursor: ns-resize;
   left: 0;
-  bottom: - $mover-outer;
+  bottom: -$mover-outer;
   width: 100%;
   height: $mover-size;
   z-index: 4;
 }
+
 .pageshot-mover-target.pageshot-bottomRight {
   cursor: nwse-resize;
-  bottom: - $mover-outer;
-  right: - $mover-outer;
+  bottom: -$mover-outer;
+  right: -$mover-outer;
   width: $mover-size;
   height: $mover-size;
 }
 
 .pageshot-mover-target:hover .pageshot-mover {
-  opacity: 1.0;
+  opacity: 1;
 }
-
 
 .pageshot-mover {
   position: absolute;
   height: $handle-size;
   width: $handle-size;
-  background-color: #348CFF;
+  background-color: #348cff;
   opacity: 0.5;
   z-index: 1001;
+
   .pageshot-small-selection & {
     height: $handle-size-small;
     width: $handle-size-small;
@@ -141,9 +155,10 @@ $overlay-z-index: 900000;
 .pageshot-top .pageshot-mover {
   top: $handle-mover-offset;
   left: 50%;
-  margin-left: - $handle-size / 2;
+  margin-left: -$handle-size / 2;
+
   .pageshot-small-selection & {
-    margin-left: - $handle-size-small / 2;
+    margin-left: -$handle-size-small / 2;
   }
 }
 
@@ -154,16 +169,17 @@ $overlay-z-index: 900000;
 
 .pageshot-left .pageshot-mover {
   top: 50%;
-  margin-top: - $handle-size / 2;
+  margin-top: -$handle-size / 2;
   left: $handle-mover-offset;
+
   .pageshot-small-selection & {
-    margin-top: - $handle-size-small / 2;
+    margin-top: -$handle-size-small / 2;
   }
 }
 
 .pageshot-right .pageshot-mover {
   top: 50%;
-  margin-top: - $handle-size / 2;
+  margin-top: -$handle-size / 2;
   right: $handle-mover-offset;
 }
 
@@ -174,10 +190,11 @@ $overlay-z-index: 900000;
 
 .pageshot-bottom .pageshot-mover {
   left: 50%;
-  margin-left: - $handle-size / 2;
+  margin-left: -$handle-size / 2;
   bottom: $handle-mover-offset;
+
   .pageshot-small-selection & {
-    margin-left: - $handle-size-small / 2;
+    margin-left: -$handle-size-small / 2;
   }
 }
 
@@ -194,45 +211,45 @@ $overlay-z-index: 900000;
 }
 
 .pageshot-textbutton {
-    position: absolute;
-    width: 20px;
-    height: 20px;
-    border: 1px solid #666;
-    box-shadow: 5px 5px 10px #999;
-    border-radius: 2px;
-    text-align: center;
-    vertical-align: center;
-    color: #000;
-    background-color: #fff;
-    z-index: 2000;
-    cursor: pointer;
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  border: 1px solid #666;
+  box-shadow: 5px 5px 10px #999;
+  border-radius: 2px;
+  text-align: center;
+  vertical-align: center;
+  color: #000;
+  background-color: #fff;
+  z-index: 2000;
+  cursor: pointer;
 }
 
 .pageshot-horizcross {
   position: fixed;
-  left: 0px;
+  left: 0;
   width: 100%;
-  height: 0px;
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  height: 0;
+  border: 1px solid rgba(#fff, 0.6);
   z-index: $overlay-z-index + 50;
 }
 
 .pageshot-vertcross {
   position: fixed;
-  top: 0px;
+  top: 0;
   height: 100%;
-  width: 0px;
-  border: 1px solid rgba(255, 255, 255, 0.6);
+  width: 0;
+  border: 1px solid rgba(#fff, 0.6);
   z-index: $overlay-z-index + 50;
 }
 
 .pageshot-preview-overlay {
   position: fixed;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   height: 100%;
   width: 100%;
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: rgba(#000, 0.5);
   z-index: $overlay-z-index;
 }
 
@@ -268,10 +285,19 @@ $overlay-z-index: 900000;
 }
 
 @keyframes pageshot-pulse {
-  0% { transform: scale(1); }
-  50% { transform: scale(1.2); }
-  100% { transform: scale(1); }
+  0% {
+    transform: scale(1);
+  }
+
+  50% {
+    transform: scale(1.2);
+  }
+
+  100% {
+    transform: scale(1);
+  }
 }
+
 
 .pageshot-horizcross.pageshot-crosshair-preview {
   top: 20%;
@@ -283,11 +309,13 @@ $overlay-z-index: 900000;
 
 .pageshot-myshots-reminder {
   @extend .pageshot-reset;
+
   display: flex;
   position: fixed;
   z-index: $overlay-z-index + 20;
   top: -17px;
   left: 10px;
+
   &.pageshot-myshots-reminder-chrome {
     top: 44px;
   }
@@ -302,15 +330,15 @@ $overlay-z-index: 900000;
 .pageshot-myshots-reminder > .pageshot-panel {
   background-clip: padding-box;
   background-color: #fcfcfc;
-  border: 1px solid rgba(24, 26, 27, .2);
-  box-shadow: 0 3px 5px rgba(24, 26, 27, .1), 0 0 7px rgba(24, 26, 27, .1);
+  border: 1px solid rgba(24, 26, 27, 0.2);
+  box-shadow: 0 3px 5px rgba(24, 26, 27, 0.1), 0 0 7px rgba(24, 26, 27, 0.1);
   box-sizing: content-box;
   color: #222426;
   cursor: default;
   display: flex;
   flex-direction: column;
   font: caption;
-  margin: 2em auto .5em;
+  margin: 2em auto 0.5em;
   padding: 0;
   position: relative;
   -moz-user-select: none;
@@ -318,7 +346,7 @@ $overlay-z-index: 900000;
 
 .pageshot-myshots-reminder > .pageshot-panel > .pageshot-panel-arrowUp {
   // From http://firefoxux.github.io/StyleGuide/static/77bfee72eee9836269c3062731a60ad7.png
-  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAOCAYAAAA1+Nx+AAABUklEQVR42p2STU6DQBSAn9ZSBFv8oVEwYdrUqtu2XsAT2Fbv0AU7woZFN5B0xYID9JhupCn1vWQ0L0AZ4+JbzAx83yMD3N65jRhidtKE6v2/iE8ZLYLvqUJKuRSeSdoMWrdUkSZ5i0k7iF6iUxeqBLbbLaxWK0iSpE6uSZnRd8QQX5ggs77jjWhPnmnlyHq9hizLII5jAN/3IQzDOnkHOTe9Sdd2xYjkeZ5/Hg6H/Xzx/oqRsSkmPQr9fA2PRFEEm80GIE3TY3KDBFxeFMUXQZG3+RIjgiLWsUgQBNAkt2x38EDy3W73Ky9HbEc8yohZFwH2p7Sr8vspn7wh8sQiOo8ALdhlmlxemVwduWQRjdwgFwZyQQ9U5WrkxcvI9ApdXenUQS4sPLhG+bgs/2fkhpzkpkCPqrY79FD+rJArI4vlxwsOOqCBKQK4ydmrReoId34DYcLiW8YxuloAAAAASUVORK5CYII=');
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAOCAYAAAA1+Nx+AAABUklEQVR42p2STU6DQBSAn9ZSBFv8oVEwYdrUqtu2XsAT2Fbv0AU7woZFN5B0xYID9JhupCn1vWQ0L0AZ4+JbzAx83yMD3N65jRhidtKE6v2/iE8ZLYLvqUJKuRSeSdoMWrdUkSZ5i0k7iF6iUxeqBLbbLaxWK0iSpE6uSZnRd8QQX5ggs77jjWhPnmnlyHq9hizLII5jAN/3IQzDOnkHOTe9Sdd2xYjkeZ5/Hg6H/Xzx/oqRsSkmPQr9fA2PRFEEm80GIE3TY3KDBFxeFMUXQZG3+RIjgiLWsUgQBNAkt2x38EDy3W73Ky9HbEc8yohZFwH2p7Sr8vspn7wh8sQiOo8ALdhlmlxemVwduWQRjdwgFwZyQQ9U5WrkxcvI9ApdXenUQS4sPLhG+bgs/2fkhpzkpkCPqrY79FD+rJArI4vlxwsOOqCBKQK4ydmrReoId34DYcLiW8YxuloAAAAASUVORK5CYII=");
   background-position: 12px top;
   background-repeat: no-repeat;
   height: 14px;
@@ -348,14 +376,17 @@ $overlay-z-index: 900000;
   background-color: #fcfcfc;
   color: #333;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen-Sans", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   height: 40px;
   width: 100%;
-  box-shadow: 0 -1px 1px rgba(0,0,0,.4) inset;
+  box-shadow: 0 -1px 1px rgba(#000, 0.4) inset;
 
-  a, a:visited, a:link, a:hover {
-    color: black;
+  a,
+  a:visited,
+  a:link,
+  a:hover {
+    color: #000;
     text-decoration: none;
   }
 
@@ -380,6 +411,7 @@ $overlay-z-index: 900000;
     background: #f4f4f4;
     font-size: 12px;
     color: #333;
+
     .pageshot-center {
       display: inline-block;
       margin-top: 8px;
@@ -390,7 +422,7 @@ $overlay-z-index: 900000;
   .pageshot-pre-myshots {
     display: inline-block;
     /* Data version of static/img/my-shots.svg */
-    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4KCjwhLS0gVGhpcyBTb3VyY2UgQ29kZSBGb3JtIGlzIHN1YmplY3QgdG8gdGhlIHRlcm1zIG9mIHRoZSBNb3ppbGxhIFB1YmxpYwogICAtIExpY2Vuc2UsIHYuIDIuMC4gSWYgYSBjb3B5IG9mIHRoZSBNUEwgd2FzIG5vdCBkaXN0cmlidXRlZCB3aXRoIHRoaXMKICAgLSBmaWxlLCBZb3UgY2FuIG9idGFpbiBvbmUgYXQgaHR0cDovL21vemlsbGEub3JnL01QTC8yLjAvLiAtLT4KCjxzdmcgdmVyc2lvbj0iMS4xIgogICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIKICAgICB3aWR0aD0iMTYiCiAgICAgaGVpZ2h0PSIxNiIKICAgICB2aWV3Qm94PSIwIDAgMTYgMTYiCiAgICAgZmlsbD0iIzRkNGQ0ZCI+CgogIDxwYXRoIGQ9Ik0xMiwxMiBMMTYsMTIgTDE2LDE0IEMxNiwxNS4xMDQ1Njk1IDE1LjExMjI3MDQsMTYgMTQsMTYgTDEyLDE2IEwxMiwxMiBMMTIsMTIgWiBNNiwxMy4wMDkzNjg5IEM2LDEyLjQ1MTkwOTggNi40NDMzNTMxOCwxMiA3LjAwOTM2ODksMTIgTDguOTkwNjMxMSwxMiBDOS41NDgwOTAxNSwxMiAxMCwxMi40NDMzNTMyIDEwLDEzLjAwOTM2ODkgTDEwLDE0Ljk5MDYzMTEgQzEwLDE1LjU0ODA5MDIgOS41NTY2NDY4MiwxNiA4Ljk5MDYzMTEsMTYgTDcuMDA5MzY4OSwxNiBDNi40NTE5MDk4NSwxNiA2LDE1LjU1NjY0NjggNiwxNC45OTA2MzExIEw2LDEzLjAwOTM2ODkgTDYsMTMuMDA5MzY4OSBaIE0wLDEyIEw0LDEyIEw0LDE2IEwyLDE2IEMwLjg5NTQzMDUsMTYgMCwxNS4xMTIyNzA0IDAsMTQgTDAsMTIgTDAsMTIgWiBNMTIsNiBMMTYsNiBMMTYsMTAgTDEyLDEwIEwxMiw2IEwxMiw2IFogTTYsNiBMMTAsNiBMMTAsMTAgTDYsMTAgTDYsNiBMNiw2IFogTTAsNiBMNCw2IEw0LDEwIEwwLDEwIEwwLDYgTDAsNiBaIE0xMiwwIEwxNCwwIEMxNS4xMDQ1Njk1LDAgMTYsMC44ODc3Mjk2NDUgMTYsMiBMMTYsNCBMMTIsNCBMMTIsMCBMMTIsMCBaIE02LDAgTDEwLDAgTDEwLDQgTDYsNCBMNiwwIEw2LDAgWiBNMCwyIEMwLDAuODk1NDMwNSAwLjg4NzcyOTY0NSwwIDIsMCBMNCwwIEw0LDQgTDAsNCBMMCwyIEwwLDIgWiIvPgoKPC9zdmc+Cg==);
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4KCjwhLS0gVGhpcyBTb3VyY2UgQ29kZSBGb3JtIGlzIHN1YmplY3QgdG8gdGhlIHRlcm1zIG9mIHRoZSBNb3ppbGxhIFB1YmxpYwogICAtIExpY2Vuc2UsIHYuIDIuMC4gSWYgYSBjb3B5IG9mIHRoZSBNUEwgd2FzIG5vdCBkaXN0cmlidXRlZCB3aXRoIHRoaXMKICAgLSBmaWxlLCBZb3UgY2FuIG9idGFpbiBvbmUgYXQgaHR0cDovL21vemlsbGEub3JnL01QTC8yLjAvLiAtLT4KCjxzdmcgdmVyc2lvbj0iMS4xIgogICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIKICAgICB3aWR0aD0iMTYiCiAgICAgaGVpZ2h0PSIxNiIKICAgICB2aWV3Qm94PSIwIDAgMTYgMTYiCiAgICAgZmlsbD0iIzRkNGQ0ZCI+CgogIDxwYXRoIGQ9Ik0xMiwxMiBMMTYsMTIgTDE2LDE0IEMxNiwxNS4xMDQ1Njk1IDE1LjExMjI3MDQsMTYgMTQsMTYgTDEyLDE2IEwxMiwxMiBMMTIsMTIgWiBNNiwxMy4wMDkzNjg5IEM2LDEyLjQ1MTkwOTggNi40NDMzNTMxOCwxMiA3LjAwOTM2ODksMTIgTDguOTkwNjMxMSwxMiBDOS41NDgwOTAxNSwxMiAxMCwxMi40NDMzNTMyIDEwLDEzLjAwOTM2ODkgTDEwLDE0Ljk5MDYzMTEgQzEwLDE1LjU0ODA5MDIgOS41NTY2NDY4MiwxNiA4Ljk5MDYzMTEsMTYgTDcuMDA5MzY4OSwxNiBDNi40NTE5MDk4NSwxNiA2LDE1LjU1NjY0NjggNiwxNC45OTA2MzExIEw2LDEzLjAwOTM2ODkgTDYsMTMuMDA5MzY4OSBaIE0wLDEyIEw0LDEyIEw0LDE2IEwyLDE2IEMwLjg5NTQzMDUsMTYgMCwxNS4xMTIyNzA0IDAsMTQgTDAsMTIgTDAsMTIgWiBNMTIsNiBMMTYsNiBMMTYsMTAgTDEyLDEwIEwxMiw2IEwxMiw2IFogTTYsNiBMMTAsNiBMMTAsMTAgTDYsMTAgTDYsNiBMNiw2IFogTTAsNiBMNCw2IEw0LDEwIEwwLDEwIEwwLDYgTDAsNiBaIE0xMiwwIEwxNCwwIEMxNS4xMDQ1Njk1LDAgMTYsMC44ODc3Mjk2NDUgMTYsMiBMMTYsNCBMMTIsNCBMMTIsMCBMMTIsMCBaIE02LDAgTDEwLDAgTDEwLDQgTDYsNCBMNiwwIEw2LDAgWiBNMCwyIEMwLDAuODk1NDMwNSAwLjg4NzcyOTY0NSwwIDIsMCBMNCwwIEw0LDQgTDAsNCBMMCwyIEwwLDIgWiIvPgoKPC9zdmc+Cg==");
     background-size: 16px 16px;
     width: 16px;
     height: 16px;
@@ -399,14 +431,14 @@ $overlay-z-index: 900000;
   .pageshot-post-myshots {
     display: inline-block;
     /* Data version of static/img/arrow-right.svg */
-    background-image: url(data:image/svg+xml;base64,PCEtLSBUaGlzIFNvdXJjZSBDb2RlIEZvcm0gaXMgc3ViamVjdCB0byB0aGUgdGVybXMgb2YgdGhlIE1vemlsbGEgUHVibGljCiAgIC0gTGljZW5zZSwgdi4gMi4wLiBJZiBhIGNvcHkgb2YgdGhlIE1QTCB3YXMgbm90IGRpc3RyaWJ1dGVkIHdpdGggdGhpcwogICAtIGZpbGUsIFlvdSBjYW4gb2J0YWluIG9uZSBhdCBodHRwOi8vbW96aWxsYS5vcmcvTVBMLzIuMC8uIC0tPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjhweCIgaGVpZ2h0PSIxNHB4IiB2aWV3Qm94PSIwIDAgOCAxNCI+CiAgPHBhdGggZmlsbD0iI2IxYjFiMSIgZD0ibTcuOTg2NzksMTMuMDEzMjFsLTAuOTkxMTksMC45OTEybC02Ljk5NTYsLTYuOTk1Nmw3LjAwODgxLC03LjAwODgxbDAuOTkxMTksMC45OTExOWwtNi4wMTc2MSw2LjAxNzYybDYuMDA0NCw2LjAwNDR6IiB0cmFuc2Zvcm09InJvdGF0ZSgtMTgwLCA0LCA3KSIvPgo8L3N2Zz4K);
+    background-image: url("data:image/svg+xml;base64,PCEtLSBUaGlzIFNvdXJjZSBDb2RlIEZvcm0gaXMgc3ViamVjdCB0byB0aGUgdGVybXMgb2YgdGhlIE1vemlsbGEgUHVibGljCiAgIC0gTGljZW5zZSwgdi4gMi4wLiBJZiBhIGNvcHkgb2YgdGhlIE1QTCB3YXMgbm90IGRpc3RyaWJ1dGVkIHdpdGggdGhpcwogICAtIGZpbGUsIFlvdSBjYW4gb2J0YWluIG9uZSBhdCBodHRwOi8vbW96aWxsYS5vcmcvTVBMLzIuMC8uIC0tPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjhweCIgaGVpZ2h0PSIxNHB4IiB2aWV3Qm94PSIwIDAgOCAxNCI+CiAgPHBhdGggZmlsbD0iI2IxYjFiMSIgZD0ibTcuOTg2NzksMTMuMDEzMjFsLTAuOTkxMTksMC45OTEybC02Ljk5NTYsLTYuOTk1Nmw3LjAwODgxLC03LjAwODgxbDAuOTkxMTksMC45OTExOWwtNi4wMTc2MSw2LjAxNzYybDYuMDA0NCw2LjAwNDR6IiB0cmFuc2Zvcm09InJvdGF0ZSgtMTgwLCA0LCA3KSIvPgo8L3N2Zz4K");
     background-size: 8px 14px;
     width: 8px;
     height: 14px;
   }
 
   .pageshot-myshots-text {
-    padding: 0px 10px;
+    padding: 0 10px;
   }
 
   button {
@@ -423,8 +455,8 @@ $overlay-z-index: 900000;
   .pageshot-save {
     border-radius: 4px;
     background: #0996f8;
-    color: white;
-    box-shadow: 0px 0px 10px #ff0;
+    color: #fff;
+    box-shadow: 0 0 10px #ff0;
     border: 1px solid #0675d3;
   }
 
@@ -434,131 +466,138 @@ $overlay-z-index: 900000;
     background-color: #fcfcfc;
     border: 1px solid #d4d4d4;
   }
-
 }
 
 /* .pageshot reset */
 /* http://yuilibrary.com/yui/docs/cssreset/ */
 .pageshot-reset {
-
-* {
+  * {
     -webkit-box-sizing: content-box !important;
     -moz-box-sizing: content-box !important;
     box-sizing: content-box !important;
-}
+  }
 
-header {
+  header {
     width: auto;
-}
+  }
 
-/*
-YUI 3.10.3 (build 2fb5187)
-Copyright 2013 Yahoo! Inc. All rights reserved.
-Licensed under the BSD License.
-http://yuilibrary.com/license/
-*/
+  /*
+  YUI 3.10.3 (build 2fb5187)
+  Copyright 2013 Yahoo! Inc. All rights reserved.
+  Licensed under the BSD License.
+  http://yuilibrary.com/license/
+  */
+  div,
+  dl,
+  dt,
+  dd,
+  ul,
+  ol,
+  li,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  pre,
+  code,
+  form,
+  fieldset,
+  legend,
+  input,
+  textarea,
+  p,
+  blockquote,
+  th,
+  td {
+    margin: 0;
+    padding: 0;
+  }
 
-div,
-dl,
-dt,
-dd,
-ul,
-ol,
-li,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-pre,
-code,
-form,
-fieldset,
-legend,
-input,
-textarea,
-p,
-blockquote,
-th,
-td {
-	margin:0;
-	padding:0;
-}
-table {
-	border-collapse:collapse;
-	border-spacing:0;
-}
-fieldset,
-img {
-	border:0;
-}
-/*
-	TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
-*/
-address,
-caption,
-cite,
-code,
-dfn,
-em,
-strong,
-th,
-var {
-	font-style:normal;
-	font-weight:normal;
-}
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
 
-ol,
-ul {
-	list-style:none;
-}
+  fieldset,
+  img {
+    border: 0;
+  }
 
-caption,
-th {
-	text-align:left;
-}
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	font-size:100%;
-	font-weight:normal;
-}
-q:before,
-q:after {
-	content:'';
-}
-abbr,
-acronym {
-	border:0;
-	font-variant:normal;
-}
-/* to preserve line-height and selector appearance */
-sup {
-	vertical-align:text-top;
-}
-sub {
-	vertical-align:text-bottom;
-}
-input,
-textarea,
-select {
-	font-family:inherit;
-	font-size:inherit;
-	font-weight:inherit;
-}
-/*to enable resizing for IE*/
-input,
-textarea,
-select {
-	*font-size:100%;
-}
-/*because legend doesn't inherit in IE */
-legend {
-	color:#000;
-}
+  /*
+  	TODO think about hanlding inheritence differently, maybe letting IE6 fail a bit...
+  */
+  address,
+  caption,
+  cite,
+  code,
+  dfn,
+  em,
+  strong,
+  th,
+  var {
+    font-style: normal;
+    font-weight: normal;
+  }
 
+  ol,
+  ul {
+    list-style: none;
+  }
+
+  caption,
+  th {
+    text-align: left;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: 100%;
+    font-weight: normal;
+  }
+
+  q::before,
+  q::after {
+    content: "";
+  }
+
+  abbr,
+  acronym {
+    border: 0;
+    font-variant: normal;
+  }
+
+  /* to preserve line-height and selector appearance */
+  sup {
+    vertical-align: text-top;
+  }
+
+  sub {
+    vertical-align: text-bottom;
+  }
+
+  input,
+  textarea,
+  select {
+    font-family: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*to enable resizing for IE*/
+  input,
+  textarea,
+  select {
+    *font-size: 100%;
+  }
+
+  /*because legend doesn't inherit in IE */
+  legend {
+    color: #000;
+  }
 }

--- a/static/css/pageshot-notification-bar.scss
+++ b/static/css/pageshot-notification-bar.scss
@@ -1,16 +1,14 @@
-
 @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul");
 
 /* Only apply to browser.xul documents */
 @-moz-document url("chrome://browser/content/browser.xul") {
-
   notification[value="pageshot-notification-bar"] {
     -moz-appearance: none;
     height: 40px;
-    padding: 0px;
+    padding: 0;
     background: #fcfcfc;
-    color: black;
-    box-shadow: 0 -1px 1px rgba(0,0,0,.4) inset;
+    color: #000;
+    box-shadow: 0 -1px 1px rgba(#000, 0.4) inset;
   }
 
   notification[value="pageshot-notification-bar"] button {
@@ -19,9 +17,9 @@
     border-radius: 4px;
     /*border: 0px;
     background: white;*/
-    margin: 0px;
+    margin: 0;
     margin-right: 5px;
-    color: black;
+    color: #000;
   }
 
   notification[value="pageshot-notification-bar"] button[label="myshots"] {
@@ -31,14 +29,14 @@
     vertical-align: middle;
     font-weight: normal;
     border-radius: 0;
-    border: none;
+    border: 0;
     background: #fcfcfc;
     color: #000;
   }
 
   notification[value="pageshot-notification-bar"] button[label="myshots"] .pre-myshots {
     /* Data version of static/img/my-shots.svg */
-    background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4KCjwhLS0gVGhpcyBTb3VyY2UgQ29kZSBGb3JtIGlzIHN1YmplY3QgdG8gdGhlIHRlcm1zIG9mIHRoZSBNb3ppbGxhIFB1YmxpYwogICAtIExpY2Vuc2UsIHYuIDIuMC4gSWYgYSBjb3B5IG9mIHRoZSBNUEwgd2FzIG5vdCBkaXN0cmlidXRlZCB3aXRoIHRoaXMKICAgLSBmaWxlLCBZb3UgY2FuIG9idGFpbiBvbmUgYXQgaHR0cDovL21vemlsbGEub3JnL01QTC8yLjAvLiAtLT4KCjxzdmcgdmVyc2lvbj0iMS4xIgogICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIKICAgICB3aWR0aD0iMTYiCiAgICAgaGVpZ2h0PSIxNiIKICAgICB2aWV3Qm94PSIwIDAgMTYgMTYiCiAgICAgZmlsbD0iIzRkNGQ0ZCI+CgogIDxwYXRoIGQ9Ik0xMiwxMiBMMTYsMTIgTDE2LDE0IEMxNiwxNS4xMDQ1Njk1IDE1LjExMjI3MDQsMTYgMTQsMTYgTDEyLDE2IEwxMiwxMiBMMTIsMTIgWiBNNiwxMy4wMDkzNjg5IEM2LDEyLjQ1MTkwOTggNi40NDMzNTMxOCwxMiA3LjAwOTM2ODksMTIgTDguOTkwNjMxMSwxMiBDOS41NDgwOTAxNSwxMiAxMCwxMi40NDMzNTMyIDEwLDEzLjAwOTM2ODkgTDEwLDE0Ljk5MDYzMTEgQzEwLDE1LjU0ODA5MDIgOS41NTY2NDY4MiwxNiA4Ljk5MDYzMTEsMTYgTDcuMDA5MzY4OSwxNiBDNi40NTE5MDk4NSwxNiA2LDE1LjU1NjY0NjggNiwxNC45OTA2MzExIEw2LDEzLjAwOTM2ODkgTDYsMTMuMDA5MzY4OSBaIE0wLDEyIEw0LDEyIEw0LDE2IEwyLDE2IEMwLjg5NTQzMDUsMTYgMCwxNS4xMTIyNzA0IDAsMTQgTDAsMTIgTDAsMTIgWiBNMTIsNiBMMTYsNiBMMTYsMTAgTDEyLDEwIEwxMiw2IEwxMiw2IFogTTYsNiBMMTAsNiBMMTAsMTAgTDYsMTAgTDYsNiBMNiw2IFogTTAsNiBMNCw2IEw0LDEwIEwwLDEwIEwwLDYgTDAsNiBaIE0xMiwwIEwxNCwwIEMxNS4xMDQ1Njk1LDAgMTYsMC44ODc3Mjk2NDUgMTYsMiBMMTYsNCBMMTIsNCBMMTIsMCBMMTIsMCBaIE02LDAgTDEwLDAgTDEwLDQgTDYsNCBMNiwwIEw2LDAgWiBNMCwyIEMwLDAuODk1NDMwNSAwLjg4NzcyOTY0NSwwIDIsMCBMNCwwIEw0LDQgTDAsNCBMMCwyIEwwLDIgWiIvPgoKPC9zdmc+Cg==);
+    background-image: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCFET0NUWVBFIHN2ZyBQVUJMSUMgIi0vL1czQy8vRFREIFNWRyAxLjEvL0VOIiAiaHR0cDovL3d3dy53My5vcmcvR3JhcGhpY3MvU1ZHLzEuMS9EVEQvc3ZnMTEuZHRkIj4KCjwhLS0gVGhpcyBTb3VyY2UgQ29kZSBGb3JtIGlzIHN1YmplY3QgdG8gdGhlIHRlcm1zIG9mIHRoZSBNb3ppbGxhIFB1YmxpYwogICAtIExpY2Vuc2UsIHYuIDIuMC4gSWYgYSBjb3B5IG9mIHRoZSBNUEwgd2FzIG5vdCBkaXN0cmlidXRlZCB3aXRoIHRoaXMKICAgLSBmaWxlLCBZb3UgY2FuIG9idGFpbiBvbmUgYXQgaHR0cDovL21vemlsbGEub3JnL01QTC8yLjAvLiAtLT4KCjxzdmcgdmVyc2lvbj0iMS4xIgogICAgIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgICB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIKICAgICB3aWR0aD0iMTYiCiAgICAgaGVpZ2h0PSIxNiIKICAgICB2aWV3Qm94PSIwIDAgMTYgMTYiCiAgICAgZmlsbD0iIzRkNGQ0ZCI+CgogIDxwYXRoIGQ9Ik0xMiwxMiBMMTYsMTIgTDE2LDE0IEMxNiwxNS4xMDQ1Njk1IDE1LjExMjI3MDQsMTYgMTQsMTYgTDEyLDE2IEwxMiwxMiBMMTIsMTIgWiBNNiwxMy4wMDkzNjg5IEM2LDEyLjQ1MTkwOTggNi40NDMzNTMxOCwxMiA3LjAwOTM2ODksMTIgTDguOTkwNjMxMSwxMiBDOS41NDgwOTAxNSwxMiAxMCwxMi40NDMzNTMyIDEwLDEzLjAwOTM2ODkgTDEwLDE0Ljk5MDYzMTEgQzEwLDE1LjU0ODA5MDIgOS41NTY2NDY4MiwxNiA4Ljk5MDYzMTEsMTYgTDcuMDA5MzY4OSwxNiBDNi40NTE5MDk4NSwxNiA2LDE1LjU1NjY0NjggNiwxNC45OTA2MzExIEw2LDEzLjAwOTM2ODkgTDYsMTMuMDA5MzY4OSBaIE0wLDEyIEw0LDEyIEw0LDE2IEwyLDE2IEMwLjg5NTQzMDUsMTYgMCwxNS4xMTIyNzA0IDAsMTQgTDAsMTIgTDAsMTIgWiBNMTIsNiBMMTYsNiBMMTYsMTAgTDEyLDEwIEwxMiw2IEwxMiw2IFogTTYsNiBMMTAsNiBMMTAsMTAgTDYsMTAgTDYsNiBMNiw2IFogTTAsNiBMNCw2IEw0LDEwIEwwLDEwIEwwLDYgTDAsNiBaIE0xMiwwIEwxNCwwIEMxNS4xMDQ1Njk1LDAgMTYsMC44ODc3Mjk2NDUgMTYsMiBMMTYsNCBMMTIsNCBMMTIsMCBMMTIsMCBaIE02LDAgTDEwLDAgTDEwLDQgTDYsNCBMNiwwIEw2LDAgWiBNMCwyIEMwLDAuODk1NDMwNSAwLjg4NzcyOTY0NSwwIDIsMCBMNCwwIEw0LDQgTDAsNCBMMCwyIEwwLDIgWiIvPgoKPC9zdmc+Cg==");
     background-size: 16px 16px;
     width: 16px;
     height: 16px;
@@ -46,22 +44,22 @@
 
   notification[value="pageshot-notification-bar"] button[label="myshots"] .post-myshots {
     /* Data version of static/img/arrow-right.svg */
-    background-image: url(data:image/svg+xml;base64,PCEtLSBUaGlzIFNvdXJjZSBDb2RlIEZvcm0gaXMgc3ViamVjdCB0byB0aGUgdGVybXMgb2YgdGhlIE1vemlsbGEgUHVibGljCiAgIC0gTGljZW5zZSwgdi4gMi4wLiBJZiBhIGNvcHkgb2YgdGhlIE1QTCB3YXMgbm90IGRpc3RyaWJ1dGVkIHdpdGggdGhpcwogICAtIGZpbGUsIFlvdSBjYW4gb2J0YWluIG9uZSBhdCBodHRwOi8vbW96aWxsYS5vcmcvTVBMLzIuMC8uIC0tPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjhweCIgaGVpZ2h0PSIxNHB4IiB2aWV3Qm94PSIwIDAgOCAxNCI+CiAgPHBhdGggZmlsbD0iI2IxYjFiMSIgZD0ibTcuOTg2NzksMTMuMDEzMjFsLTAuOTkxMTksMC45OTEybC02Ljk5NTYsLTYuOTk1Nmw3LjAwODgxLC03LjAwODgxbDAuOTkxMTksMC45OTExOWwtNi4wMTc2MSw2LjAxNzYybDYuMDA0NCw2LjAwNDR6IiB0cmFuc2Zvcm09InJvdGF0ZSgtMTgwLCA0LCA3KSIvPgo8L3N2Zz4K);
+    background-image: url("data:image/svg+xml;base64,PCEtLSBUaGlzIFNvdXJjZSBDb2RlIEZvcm0gaXMgc3ViamVjdCB0byB0aGUgdGVybXMgb2YgdGhlIE1vemlsbGEgUHVibGljCiAgIC0gTGljZW5zZSwgdi4gMi4wLiBJZiBhIGNvcHkgb2YgdGhlIE1QTCB3YXMgbm90IGRpc3RyaWJ1dGVkIHdpdGggdGhpcwogICAtIGZpbGUsIFlvdSBjYW4gb2J0YWluIG9uZSBhdCBodHRwOi8vbW96aWxsYS5vcmcvTVBMLzIuMC8uIC0tPgo8c3ZnIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjhweCIgaGVpZ2h0PSIxNHB4IiB2aWV3Qm94PSIwIDAgOCAxNCI+CiAgPHBhdGggZmlsbD0iI2IxYjFiMSIgZD0ibTcuOTg2NzksMTMuMDEzMjFsLTAuOTkxMTksMC45OTEybC02Ljk5NTYsLTYuOTk1Nmw3LjAwODgxLC03LjAwODgxbDAuOTkxMTksMC45OTExOWwtNi4wMTc2MSw2LjAxNzYybDYuMDA0NCw2LjAwNDR6IiB0cmFuc2Zvcm09InJvdGF0ZSgtMTgwLCA0LCA3KSIvPgo8L3N2Zz4K");
     background-size: 8px 14px;
     width: 8px;
     height: 14px;
   }
 
   notification[value="pageshot-notification-bar"] button[label="myshots"] .myshots-text {
-    padding: 0px 10px;
+    padding: 0 10px;
   }
 
   notification[value="pageshot-notification-bar"] button[label="Save"],
   notification[value="pageshot-notification-bar"] button[label="Save Full Page"] {
     border-radius: 4px;
     background: #2fa8e1;
-    color: white;
-    box-shadow: 0px 0px 10px #ff0;
+    color: #fff;
+    box-shadow: 0 0 10px #ff0;
   }
 
   notification[value="pageshot-notification-bar"] button[label="Cancel"] {

--- a/static/css/panel.scss
+++ b/static/css/panel.scss
@@ -104,8 +104,8 @@ a:hover {
 }
 
 .mode-selected {
-  border: 2px solid rgba(0, 149, 221, 0.5);
-  background-color: rgba(0, 149, 221, 0.1);
+  border: 2px solid rgba(#0095dd, 0.5);
+  background-color: rgba(#0095dd, 0.1);
 }
 
 .clip-selector {
@@ -447,7 +447,7 @@ a.simplified-link:link {
 }
 
 a.simplified-link-border {
-  border: 2px solid rgba(0, 137, 219, 1);
+  border: 2px solid rgba(#0089db, 1);
   border-radius: 2px;
 }
 

--- a/static/css/panel.scss
+++ b/static/css/panel.scss
@@ -9,9 +9,10 @@ Panels should have a structure like:
 
 */
 
-$shadow-color: rgba(0, 0, 0, 0.5);
+$shadow-color: rgba(#000, 0.5);
 
-html, body {
+html,
+body {
   margin: 0;
   height: 100%;
 }
@@ -64,17 +65,17 @@ a:hover {
 
 .container {
   position: absolute;
-  top: 0px;
-  left: 0px;
-  bottom: 0px;
-  right: 0px;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
   overflow: hidden;
 }
 
 .alpha-badge {
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   pointer-events: none;
 }
 
@@ -108,7 +109,7 @@ a:hover {
 }
 
 .clip-selector {
-  padding: 0 5px 0 5px;
+  padding: 0 5px;
   font-size: 16px;
   cursor: pointer;
 }
@@ -124,18 +125,18 @@ a:hover {
 .clips-row {
   position: absolute;
   bottom: 4.5em;
-  left: 0px;
-  right: 0px;
+  left: 0;
+  right: 0;
   text-align: center;
 }
 
 .link-row {
   position: absolute;
-  top: 0px;
-  left: 0px;
-  right: 0px;
+  top: 0;
+  left: 0;
+  right: 0;
   height: 2em;
-  background-color: #E4E4E4;
+  background-color: #e4e4e4;
   font-size: 15px;
 }
 
@@ -143,7 +144,7 @@ a:hover {
   position: absolute;
   width: 45%;
   top: 8px;
-  right: 0px;
+  right: 0;
 }
 
 .link {
@@ -159,10 +160,10 @@ a:hover {
 .share-row-container {
   position: absolute;
   top: 2em;
-  left: 0px;
-  right: 0px;
+  left: 0;
+  right: 0;
   height: 1.5em;
-  background-color: #E4E4E4;
+  background-color: #e4e4e4;
 }
 
 .share-row {
@@ -183,9 +184,9 @@ a:hover {
 
 .feedback-row {
   position: absolute;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
+  bottom: 0;
+  left: 0;
+  right: 0;
   height: 2em;
   font-size: 12px;
   background-color: #eaeaea;
@@ -212,7 +213,7 @@ a:hover {
   right: 0.5em;
   bottom: 5.5em;
   overflow: auto;
-  display:flex;
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   justify-content: center;
@@ -261,7 +262,7 @@ img.clip-image {
 }
 
 .button-row {
-  margin: 10px 30px 10px 30px;
+  margin: 10px 30px;
 }
 
 .button-row button {
@@ -288,8 +289,8 @@ img.clip-image {
 /* Recall-related styles: */
 
 ul.recall-list {
-  padding: 0px;
-  margin: 0px;
+  padding: 0;
+  margin: 0;
   margin-top: 0.125em;
 }
 
@@ -324,7 +325,7 @@ ul.recall-list li:hover {
   width: 1em;
   overflow: hidden;
   cursor: pointer;
-  background-image: url(copy.png);
+  background-image: url("copy.png");
   background-size: 1em;
   background-position: right;
   background-repeat: no-repeat;
@@ -338,7 +339,8 @@ ul.recall-list li:hover {
   text-overflow: ellipsis;
 }
 
-.title .empty-favicon, .title .favicon {
+.title .empty-favicon,
+.title .favicon {
   display: inline-block;
   width: 16px;
   height: 16px;
@@ -361,9 +363,9 @@ ul.recall-list li:hover {
 
 .see-more-row {
   position: absolute;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
+  bottom: 0;
+  left: 0;
+  right: 0;
   height: 33px;
   padding: 0.5em;
   border-top: 1px solid #ccc;
@@ -372,7 +374,8 @@ ul.recall-list li:hover {
   font-size: 13px;
 }
 
-.see-more-row a, .see-more-row a:visited {
+.see-more-row a,
+.see-more-row a:visited {
   position: relative;
   top: 10px;
   display: block;
@@ -381,7 +384,7 @@ ul.recall-list li:hover {
 
 .recall-back {
   position: absolute;
-  color: blue;
+  color: #00f;
   cursor: pointer;
   top: 10px;
   left: -7px;
@@ -407,7 +410,6 @@ ul.recall-list li:hover {
   left: 0.5em;
   right: 0.5em;
   height: 1em;
-  font-size: small;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
@@ -417,13 +419,13 @@ ul.recall-list li:hover {
 
 .simplified-instructions {
   position: absolute;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  padding: 0px;
+  top: 0;
+  left: 0;
+  right: 0;
+  padding: 0;
   background-color: #eaeaea;
   text-align: center;
-  border-bottom: 1px solid #cccccc;
+  border-bottom: 1px solid #ccc;
 }
 
 .instructions-text {
@@ -435,7 +437,9 @@ ul.recall-list li:hover {
   margin-bottom: 0.5em;
 }
 
-a.simplified-link, a.simplified-link:visited, a.simplified-link:link {
+a.simplified-link,
+a.simplified-link:visited,
+a.simplified-link:link {
   padding: 0.25em;
   font-size: 24px;
   color: #0095dd;
@@ -462,14 +466,15 @@ a.simplified-link-border {
   left: 0.5em;
   right: 0.5em;
   text-align: center;
+
   button {
     margin: 0 16px;
   }
 }
 
 .simplified-edit-button {
-  background-color: #FBFBFB;
-  border: 1px solid #C1C1C1;
+  background-color: #fbfbfb;
+  border: 1px solid #c1c1c1;
   border-radius: 2px;
   color: #333;
   font-size: 13.75px;
@@ -479,11 +484,11 @@ a.simplified-link-border {
 }
 
 .simplified-edit-button:hover {
-  background-color: #EBEBEB;
+  background-color: #ebebeb;
 }
 
 .simplified-edit-button:active {
-  background-color: #DADADA;
+  background-color: #dadada;
 }
 
 .warning {

--- a/static/css/profile.scss
+++ b/static/css/profile.scss
@@ -5,7 +5,7 @@
 
 .panel {
   border-radius: 5px;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 2px 5px rgba(#000, 0.5);
   background: #fff;
   color: #000;
   padding: 1em;
@@ -13,11 +13,13 @@
   font-size: 13px;
 }
 
-.panel a, .panel a:visited {
+.panel a,
+.panel a:visited {
   color: #0095dd;
 }
 
-.panel a:hover, .panel a:focus {
+.panel a:hover,
+.panel a:focus {
   text-decoration: none;
 }
 
@@ -25,10 +27,10 @@
   text-align: center;
   height: 80px;
   width: 80px;
-}
 
-.avatar-container img {
-  height: 100%;
+  img {
+    height: 100%;
+  }
 }
 
 #profile {
@@ -44,7 +46,7 @@
   margin-top: 10px;
 }
 
-.panel input[type=text] {
+.panel input[type="text"] {
   // FIXME: when 100%, it goes over the padding of the .panel, making it not
   // be centered
   width: 95%;
@@ -54,8 +56,8 @@
 .sync-buttons {
   list-style: none;
   padding-left: 0;
-}
 
-.sync-buttons li {
-  margin-top: 0.5em;
+  li {
+    margin-top: 0.5em;
+  }
 }

--- a/static/css/shot-index.scss
+++ b/static/css/shot-index.scss
@@ -20,7 +20,7 @@ body {
   justify-content: center;
   flex-direction: row;
   flex-wrap: wrap;
-  padding: 0px;
+  padding: 0;
 }
 
 .shot {
@@ -30,7 +30,9 @@ body {
   background-color: #fff;
   cursor: pointer;
 
-  & a, & a:visited, & a:link {
+  & a,
+  & a:visited,
+  & a:link {
     color: #000;
     text-decoration: none;
   }
@@ -48,14 +50,17 @@ body {
 
 .title-container {
   padding: 10px 15px 15px;
+
   & > h2 {
-    margin: 0px 0px 10px;
+    margin: 0 0 10px;
+
     & > a {
       color: #000;
       font-size: 16px;
       text-decoration: none;
     }
   }
+
   & > .link-container {
     & > a {
       height: 20px;
@@ -66,6 +71,7 @@ body {
       color: #0996f8;
       border-radius: 2px;
     }
+
     & > .favicon {
       background-size: cover;
       display: inline-block;

--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -615,5 +615,5 @@ a.subheading-link {
 
 .intro-js-highlight-overlay {
   background: rgba(#000, 0);
-  border: 2px solid rgba(0, 137, 219, 1);
+  border: 2px solid rgba(#0089db, 1);
 }

--- a/static/css/styles.scss
+++ b/static/css/styles.scss
@@ -2,8 +2,7 @@ $primary-color: #fcfcfc;
 $toolbar-text-color: #464239;
 $text-color: #f2f2f2;
 $background-color: #282d33;
-$shadow-color: rgba(0, 0, 0, 0.5);
-
+$shadow-color: rgba(#000, 0.5);
 
 html {
   height: 100%;
@@ -22,17 +21,17 @@ body {
 
 #container {
   position: absolute;
-  left: 0px;
-  right: 0px;
-  top: 0px;
-  padding-top: 0px;
-  padding-left: 0px;
-  padding-right: 0px;
+  left: 0;
+  right: 0;
+  top: 0;
+  padding-top: 0;
+  padding-left: 0;
+  padding-right: 0;
   text-align: center;
 }
 
 #frame {
-  border: none;
+  border: 0;
   margin-top: 65px;
   margin-bottom: 4em;
   box-shadow: 0 -5px 5px $shadow-color;
@@ -40,9 +39,9 @@ body {
 
 #toolbar {
   position: fixed;
-  top: 0px;
-  left: 0px;
-  right: 0px;
+  top: 0;
+  left: 0;
+  right: 0;
   height: 35px;
   padding: 15px;
   padding-left: 150px;
@@ -54,7 +53,7 @@ body {
   color: $toolbar-text-color;
   text-align: left;
   background-color: $primary-color;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 1px 2px rgba(#000, 0.5);
 }
 
 #private-notice {
@@ -67,7 +66,7 @@ body {
   padding: 7px;
   padding-bottom: 1px;
   background-color: #ebd55a;
-  color: black;
+  color: #000;
   cursor: pointer;
   z-index: 2;
 }
@@ -100,22 +99,22 @@ body {
 
 #navigate-toolbar {
   position: fixed;
-  top: 0px;
-  right: 0px;
+  top: 0;
+  right: 0;
   padding: 14px;
   z-index: 2;
   height: 23px;
   width: 160px;
   text-align: right;
-  text-shadow: 1px 1px 2px black;
+  text-shadow: 1px 1px 2px #000;
   font-size: 12px;
 }
 
 #full-page-button {
   position: fixed;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   height: 2em;
   text-align: center;
   z-index: 1001;
@@ -127,8 +126,8 @@ body {
 
 #full-screen-thumbnail {
   position: fixed;
-  left: 0px;
-  right: 0px;
+  left: 0;
+  right: 0;
   bottom: 2em;
   text-align: center;
   z-index: 1001;
@@ -151,24 +150,25 @@ body {
 }
 
 .full-page-button-arrow {
-  color: #333333;
+  color: #333;
 }
 
 .full-page-button-text {
-  color: #000000;
+  color: #000;
 }
 
 .full-page-button-styles {
-  background-color: #ffffff;
-  background-image: linear-gradient(#ffffff, #f4f4f4);
+  background-color: #fff;
+  background-image: linear-gradient(#fff, #f4f4f4);
   border-radius: 99px;
   color: #0095dd;
   display: inline-block;
   font-size: 12px;
-  padding: .4em 1.5em;
+  padding: 0.4em 1.5em;
   text-decoration: none;
   border: 1px solid #ababab;
 }
+
 .clip-count {
   position: relative;
   bottom: 7px;
@@ -181,7 +181,8 @@ body {
   right: 0.5em;
 }
 
-a, a:visited {
+a,
+a:visited {
   text-decoration: none;
   color: $text-color;
 }
@@ -197,11 +198,11 @@ a:hover {
   border: 1px solid #d4d4d4;
   padding: 4px;
   border-radius: 4px;
+
   &.delete-button {
-    color: #dd0000;
+    color: #d00;
   }
 }
-
 
 #info {
   position: absolute;
@@ -219,7 +220,8 @@ a#collection-link {
   text-decoration: underline;
 }
 
-a.sitelink, a.sitelink:visited {
+a.sitelink,
+a.sitelink:visited {
 }
 
 #comment-container {
@@ -235,7 +237,7 @@ a.sitelink, a.sitelink:visited {
   border-left: 2px solid #E66000; */
   border-radius: 0 0 4px 4px;
   z-index: 100;
-  background-color: #00539F;
+  background-color: #00539f;
   cursor: pointer;
 }
 
@@ -257,12 +259,12 @@ a.sitelink, a.sitelink:visited {
 
 .clip-container {
   position: fixed;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
-  padding-top: 0px;
-  background-color: rgba(0, 0, 0, 0.80);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding-top: 0;
+  background-color: rgba(#000, 0.8);
 }
 
 .clip-container div {
@@ -271,19 +273,19 @@ a.sitelink, a.sitelink:visited {
 
 .clip-container a img {
   max-width: 85%;
-  border: 1px solid rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(#000, 0.5);
   box-shadow: 0 6px 20px $shadow-color;
 }
 
 .text-clip {
-  background-color: white;
-  color: black;
+  background-color: #fff;
+  color: #000;
   border: 1px solid #aaa;
   box-shadow: 0 2px 5px $shadow-color;
 }
 
 .text-clip a {
-  color: black;
+  color: #000;
 }
 
 .clip-anchor-link {
@@ -306,8 +308,8 @@ a.sitelink, a.sitelink:visited {
 }
 
 .white-background {
-  background-color: white;
-  color: black;
+  background-color: #fff;
+  color: #000;
   text-align: left;
 }
 
@@ -323,12 +325,12 @@ a.sitelink, a.sitelink:visited {
 
 .my-shots-button {
   position: absolute;
-  top: 0px;
-  left: 0px;
+  top: 0;
+  left: 0;
   width: 125px;
   height: 66px;
   background: #ebebeb;
-  border: none;
+  border: 0;
   cursor: pointer;
 }
 
@@ -370,7 +372,7 @@ a.sitelink, a.sitelink:visited {
 .share-button {
   margin-left: 15px;
   background: #0996f8;
-  color: white;
+  color: #fff;
   border-radius: 4px;
   border: 1px solid #0675d3;
   height: 32px;
@@ -386,7 +388,7 @@ a.sitelink, a.sitelink:visited {
   border: 1px solid #d4d4d4;
   height: 32px;
   background: transparent;
-  color: black;
+  color: #000;
   cursor: pointer;
   vertical-align: middle;
   padding: 6px 15px;
@@ -396,10 +398,10 @@ a.sitelink, a.sitelink:visited {
 .flag-button {
   margin-left: 15px;
   border-radius: 4px;
-  border: 1px solid rgba(0,0,0,.35);
+  border: 1px solid rgba(#000, 0.35);
   height: 32px;
   background: #fcfcfc;
-  color: black;
+  color: #000;
   cursor: pointer;
   vertical-align: middle;
   padding: 8px 15px;
@@ -411,10 +413,10 @@ a.sitelink, a.sitelink:visited {
   right: 15px;
   z-index: 99;
   border-radius: 4px;
-  border: 1px solid rgba(0,0,0,.35);
+  border: 1px solid rgba(#000, 0.35);
   box-shadow: 0 -2px 5px $shadow-color;
-  color: black;
-  background-color: white;
+  color: #000;
+  background-color: #fff;
   padding: 15px;
   text-align: left;
 }
@@ -445,11 +447,11 @@ a.sitelink, a.sitelink:visited {
 
 .copy-shot-link-button {
   background: #2fa8e1;
-  color: white;
+  color: #fff;
   border-radius: 4px;
-  border-top-left-radius: 0px;
-  border-bottom-left-radius: 0px;
-  border: 1px solid rgba(0,0,0,.35);
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border: 1px solid rgba(#000, 0.35);
   height: 28px;
   width: 75px;
   cursor: pointer;
@@ -457,8 +459,8 @@ a.sitelink, a.sitelink:visited {
 
 .more-shot-actions {
   position: absolute;
-  top: 0px;
-  right: 0px;
+  top: 0;
+  right: 0;
   height: 33px;
   padding: 15px;
   color: #959595;
@@ -491,7 +493,7 @@ a.sitelink, a.sitelink:visited {
   top: 80px;
   left: -60px;
   transform: rotate(-45deg);
-  box-shadow: 0px 6px 20px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 6px 20px rgba(#000, 0.5);
 }
 
 a.subheading-link {
@@ -527,20 +529,20 @@ a.subheading-link {
 }
 
 .comment-holder {
-  //line-height: 36px;
+  // line-height: 36px;
   display: inline-block;
   position: relative;
   top: -3.25em;
   width: 400px;
   background-color: $text-color;
   color: $primary-color;
-  border-radius: 4px 4px 4px 4px;
+  border-radius: 4px;
   text-align: left;
 }
 
 .comment-holder div {
   margin: 0;
-  padding: 15px 20px 15px 20px;
+  padding: 15px 20px;
 }
 
 .comment-user {
@@ -561,9 +563,9 @@ a.subheading-link {
 
 #use-pageshot-to-create {
   position: fixed;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   padding: 1em;
   padding-right: 3em;
   background-color: $text-color;
@@ -578,14 +580,14 @@ a.subheading-link {
 
 #banner-close {
   position: absolute;
-  right: 0px;
-  top: 0px;
+  right: 0;
+  top: 0;
   padding: 1em;
   cursor: pointer;
 }
 
 .navigate-clips {
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: rgba(#fff, 0.05);
 }
 
 /* When the clip navigation buttons are disabled: */
@@ -599,12 +601,12 @@ a.subheading-link {
 .button {
   // FIXME: copied from panel.scss .simplified-edit-button
   display: inline-block;
-  background-color: #5CB85C;
+  background-color: #5cb85c;
   color: #fff;
   font-size: 18px;
   padding: 6px 12px;
   border-radius: 6px;
-  border: 1px solid #4CAE4C;
+  border: 1px solid #4cae4c;
 
   &:hover {
     text-decoration: underline;
@@ -612,6 +614,6 @@ a.subheading-link {
 }
 
 .intro-js-highlight-overlay {
-  background: rgba(0,0,0,0);
+  background: rgba(#000, 0);
   border: 2px solid rgba(0, 137, 219, 1);
 }


### PR DESCRIPTION
Ref: #1212 

Turns out you can mostly clean your Sass by converting your SCSS to SCSS using Sass' `sass-convert` tool:

```sh
$ sass-convert static/css -R -T scss -F scss -i
```

This leaves us with 24 warnings which will consider a bit more thought (or relaxing of sass-lint rules):

```sh
$ npm run sass

> pageshot@0.0.1 sass /Users/pdehaan/dev/github/mozilla-services/pageshot
> sass-lint -v -q


./static/css/inline-selection.scss
   63:24  warning  Class '.pageshot-topLeft' should be written in lowercase with hyphens                      class-name-format
   81:24  warning  Class '.pageshot-topRight' should be written in lowercase with hyphens                     class-name-format
  107:24  warning  Class '.pageshot-bottomLeft' should be written in lowercase with hyphens                   class-name-format
  124:24  warning  Class '.pageshot-bottomRight' should be written in lowercase with hyphens                  class-name-format
  150:2   warning  Class '.pageshot-topLeft' should be written in lowercase with hyphens                      class-name-format
  165:2   warning  Class '.pageshot-topRight' should be written in lowercase with hyphens                     class-name-format
  186:2   warning  Class '.pageshot-bottomLeft' should be written in lowercase with hyphens                   class-name-format
  201:2   warning  Class '.pageshot-bottomRight' should be written in lowercase with hyphens                  class-name-format
  311:11  warning  @extend must be used with a %placeholder                                                   placeholder-in-extend
  344:3   warning  Vendor prefixes should not be used                                                         no-vendor-prefixes
  347:49  warning  Class '.pageshot-panel-arrowUp' should be written in lowercase with hyphens                class-name-format
  373:11  warning  @extend must be used with a %placeholder                                                   placeholder-in-extend
  475:5   warning  Vendor prefixes should not be used                                                         no-vendor-prefixes
  476:5   warning  Vendor prefixes should not be used                                                         no-vendor-prefixes
  593:3   warning  Rule `.pageshot-reset input, textarea, select` should be merged with the rule on line 584  no-mergeable-selectors
  596:5   warning  Property `*font-size` appears to be spelled incorrectly                                    no-misspelled-properties

./static/css/pageshot-notification-bar.scss
   1:78  warning  Protocols and domains in URLs are disallowed                       no-url-protocols
   4:2   warning  Vendor prefixes should not be used                                 no-vendor-prefixes
   6:5   warning  Vendor prefixes should not be used                                 no-vendor-prefixes
  74:52  warning  Class '.messageImage' should be written in lowercase with hyphens  class-name-format

./static/css/panel.scss
  252:10  warning  No empty blocks allowed  no-empty-rulesets

./static/css/styles.scss
  224:20  warning  No empty blocks allowed  no-empty-rulesets
  316:12  warning  No empty blocks allowed  no-empty-rulesets
  521:10  warning  No empty blocks allowed  no-empty-rulesets

✖ 24 problems (0 errors, 24 warnings)
```
