### PR TITLE
r?fzzzy Fix #1370, avoid performance problems with a late-stage document mous…

### DIFF
--- a/addon/data/shooter-interactive-worker.js
+++ b/addon/data/shooter-interactive-worker.js
@@ -614,7 +614,7 @@ function addHandlers() {
         return handler[eventName](event);
       }
     }).bind(null, eventName));
-    document.addEventListener(eventName, fn, false);
+    document.addEventListener(eventName, fn, true);
     registeredDocumentHandlers[eventName] = fn;
   });
   document.addEventListener("keyup", keyupHandler, false);


### PR DESCRIPTION
…emove hander

By using the useCapture=true argument, mousemove fires before any bubbling, which causes problems on complicated pages like Google Maps