### PR TITLE
Remove 'X-Powered-By: Express' header

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -137,6 +137,9 @@ const app = express();
 
 app.set('trust proxy', true);
 
+// Disable x-powered-by header
+app.disable("x-powered-by");
+
 const CONTENT_NAME = config.contentOrigin;
 
 app.use((req, res, next) => {


### PR DESCRIPTION
Removes the `X-Powered-By: Express` header, because would we need that.

```sh
$ curl https://pageshot.net/ -v

*   Trying 52.42.215.50...
* Connected to pageshot.net (52.42.215.50) port 443 (#0)
* TLS 1.2 connection using TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
* Server certificate: pageshot.net
* Server certificate: DigiCert SHA2 Secure Server CA
* Server certificate: DigiCert Global Root CA
> GET / HTTP/1.1
> Host: pageshot.net
> User-Agent: curl/7.43.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Security-Policy: default-src 'self'; img-src 'self' www.google-analytics.com pageshot-usercontent.net data:; script-src 'self' www.google-analytics.com 'nonce-3c6f902d-144c-4d03-993c-42d4a0fff2f8'; style-src 'self' 'unsafe-inline' https://code.cdn.mozilla.net; connect-src 'self' www.google-analytics.com
< Content-Type: text/html; charset=utf-8
< Date: Tue, 30 Aug 2016 17:20:16 GMT
< ETag: W/"38e-NlivlghnOjrnim4E4qhb6A"
< X-Powered-By: Express
< Content-Length: 910
< Connection: keep-alive
```