### PR TITLE
added circle.yml

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ static/vendor
 /Profile
 /build
 /webextension/build
+/firefox

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,34 @@
+machine:
+  node:
+    version: 6.10.0
+  environment:
+    RDS_NAME: circle_test
+    RDS_USERNAME: ubuntu
+    LOCALHOST_SSL: false
+    DISPLAY: ":99.0"
+    PATH: "/home/ubuntu/pageshot/firefox:$PATH"
+
+dependencies:
+  pre:
+    # we want firefox nightly in order to install an unsigned pageshot addon
+    - pip install mozdownload mozinstall
+    - mozdownload --version latest --type daily --destination firefox.tar.bz2
+    - mozinstall firefox.tar.bz2
+    - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+
+compile:
+  override:
+    - make all
+
+test:
+  override:
+    - firefox -v
+    # addon tests
+    - npm test
+    # server tests
+    - node -e 'require("babel-polyfill"); require("./build/server/server");':
+        background: true
+    - ./bin/test-request put '{}'
+
+  post:
+    - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The server tests I hoped to add with this aren't quite ready so this just adds the basic skeleton. It runs the addon tests, starts a server and uses the existing `test-request` to make sure everything is basically ok. It's also set up to report to codecov once we have test coverage.