### PR TITLE
Fix #2197, reintroduce the /creating page

### DIFF
--- a/webextension/background/main.js
+++ b/webextension/background/main.js
@@ -74,7 +74,6 @@ window.main = (function () {
         + pasteSymbol + "-V to paste."
       });
     }
-    chrome.tabs.create({url});
   });
 
   return exports;


### PR DESCRIPTION
Open /creating page right away, and navigate to the shot page once the upload is complete

To test you have to run the local server like this:

    TEST_SLOW_RESPONSE=20000 ./bin/run-server

Then it's really slow and you see the creating page.