### PR TITLE
Fixes #2318: Provides export_addon makefile rule to export pageshot into a mozilla-central based repository.

### DIFF
--- a/docs/export-to-firefox.md
+++ b/docs/export-to-firefox.md
@@ -1,0 +1,14 @@
+# Exporting to Firefox
+
+Page Shot is developed in GitHub, but on each release we export into the Firefox source tree.
+
+To start the process, check Firefox out into some location, we'll say `~/src/gecko`
+
+Then run:
+
+```sh
+$ EXPORT_MC_LOCATION=~/src/gecko make export_addon
+$ cd ~/src/gecko
+$ hg status
+# Now add or remove files to create a commit
+```


### PR DESCRIPTION
The environment variable EXPORT_MC_LOCATION provides for changing where the add-on is exported to.