### PR TITLE
disable the pageshot button on about,data,moz-extension pages

### DIFF
--- a/addon/webextension/background/main.js
+++ b/addon/webextension/background/main.js
@@ -40,8 +40,12 @@ window.main = (function () {
       });
   }
 
+  function opensMyShots(url) {
+    return /^about:(?:newtab|blank)/i.test(url) || /^resource:\/\/activity-streams\//i.test(url);
+  }
+
   browser.browserAction.onClicked.addListener(catcher.watchFunction((tab) => {
-    if (tab.url.match(/about:(newtab|blank)/i)) {
+    if (opensMyShots(tab.url)) {
       catcher.watchPromise(analytics.refreshTelemetryPref().then(() => {
         sendEvent("goto-myshots", "about-newtab");
       }));
@@ -77,6 +81,26 @@ window.main = (function () {
         .then(() => sendEvent("start-shot", "context-menu")));
   }));
 
+  function urlEnabled(url) {
+    if (opensMyShots(url)) {
+      return true;
+    }
+    if (url.startsWith(backend) || /^(?:about|data|moz-extension):/i.test(url)) {
+      return false;
+    }
+    return true;
+  }
+
+  browser.tabs.onUpdated.addListener((id, info, tab) => {
+    if (info.url && tab.selected) {
+      if (urlEnabled(info.url)) {
+        browser.browserAction.enable(tab.id);
+      }
+      else {
+        browser.browserAction.disable(tab.id);
+      }
+    }
+  });
 
   communication.register("sendEvent", (sender, ...args) => {
     catcher.watchPromise(sendEvent(...args));

--- a/addon/webextension/manifest.json.template
+++ b/addon/webextension/manifest.json.template
@@ -61,6 +61,7 @@
   ],
   "permissions": [
     "activeTab",
+    "tabs",
     "storage",
     "notifications",
     "clipboardWrite",


### PR DESCRIPTION
It seems like disabling the pageshot button on these pages is better than doing anything else. It needs the `tabs` permission (I don't know if that's ok or not) since `activeTab` doesn't kick in until a user action is performed.

I don't know what to do about framesets yet.

closes #2236 