### PR TITLE
Pass empty strings, not null, to notifications API

### DIFF
--- a/addon/webextension/background/senderror.js
+++ b/addon/webextension/background/senderror.js
@@ -48,7 +48,7 @@ window.errorpopup = (function () {
       popupMessage = "generic";
     }
     let title = messages[popupMessage].title;
-    let message = messages[popupMessage].message || null;
+    let message = messages[popupMessage].message || '';
     let showMessage = messages[popupMessage].showMessage;
     if (error.message && showMessage) {
       if (message) {


### PR DESCRIPTION
`browser.notifications.create` will throw if you pass it a `null` message, but it's fine if the message is an empty string.

Fixes the odd error message I've been seeing in the browser desktop notifications today:

Before:

![screen shot 2017-03-20 at 1 46 58 pm](https://cloud.githubusercontent.com/assets/96396/24126263/40a9da88-0d8a-11e7-8d88-0f977e417bad.png)

After:

![screen shot 2017-03-20 at 4 30 08 pm](https://cloud.githubusercontent.com/assets/96396/24126317/84e59476-0d8a-11e7-8ce8-b4a80ea0cf0c.png)
